### PR TITLE
Fix invalid nested ul

### DIFF
--- a/jekyll-toc.gemspec
+++ b/jekyll-toc.gemspec
@@ -15,10 +15,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.post_install_message = %q(As of jekyll-toc 0.3, nested toc is supported! Please make sure your toc is not broken after update jekyll-toc.
-
-For more info: https://github.com/toshimaru/jekyll-toc/wiki/0.3-Upgrade-Guide)
-
   spec.required_ruby_version = '>= 2.1.0'
 
   spec.add_runtime_dependency 'nokogiri', '~> 1.6'

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -83,7 +83,7 @@ module Jekyll
             # If the current entry should be indented in the list, generate a sublist
             nest_entries = get_nest_entries(entries[i, entries.count], min_h_num)
             if last_ul_used
-              toc_list << build_toc_list(nest_entries)
+              toc_list << build_toc_list(nest_entries, last_ul_used: true)
             else
               toc_list << %(<ul>\n#{build_toc_list(nest_entries, last_ul_used: true)}</ul>\n)
             end

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -10,7 +10,7 @@ module Jekyll
       end
 
       def build_toc
-        %(<ul class="section-nav">\n#{build_toc_list(@entries)}</ul>)
+        %(<ul class="section-nav">\n#{build_toc_list(@entries, last_ul_used: true)}</ul>)
       end
 
       def inject_anchors_into_html

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -4,8 +4,6 @@ module Jekyll
     class Parser
       PUNCTUATION_REGEXP = /[^\p{Word}\- ]/u
 
-      attr_reader :doc
-
       def initialize(html)
         @doc = Nokogiri::HTML::DocumentFragment.parse(html)
         @entries = parse_content

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -58,7 +58,7 @@ module Jekyll
       end
 
       # Returns the list items for entries
-      def build_toc_list(entries)
+      def build_toc_list(entries, last_ul_used: false)
         i = 0
         toc_list = ''
         min_h_num = entries.map { |e| e[:h_num] }.min
@@ -73,7 +73,7 @@ module Jekyll
               next_entry = entries[i + 1]
               if next_entry[:h_num] > min_h_num
                 nest_entries = get_nest_entries(entries[i + 1, entries.count], min_h_num)
-                toc_list << %(\n<ul>\n#{build_toc_list(nest_entries)}</ul>\n)
+                toc_list << %(\n<ul>\n#{build_toc_list(nest_entries, last_ul_used: true)}</ul>\n)
                 i += nest_entries.count
               end
             end
@@ -82,7 +82,13 @@ module Jekyll
           elsif entry[:h_num] > min_h_num
             # If the current entry should be indented in the list, generate a sublist
             nest_entries = get_nest_entries(entries[i, entries.count], min_h_num)
-            toc_list << %(<ul>\n#{build_toc_list(nest_entries)}</ul>\n)
+            if last_ul_used
+              toc_list << build_toc_list(nest_entries)
+              last_ul_used = false
+            else
+              toc_list << %(<ul>\n#{build_toc_list(nest_entries, last_ul_used: true)}</ul>\n)
+              last_ul_used = true
+            end
             i += nest_entries.count - 1
           end
           i += 1

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -84,10 +84,8 @@ module Jekyll
             nest_entries = get_nest_entries(entries[i, entries.count], min_h_num)
             if last_ul_used
               toc_list << build_toc_list(nest_entries)
-              last_ul_used = false
             else
               toc_list << %(<ul>\n#{build_toc_list(nest_entries, last_ul_used: true)}</ul>\n)
-              last_ul_used = true
             end
             i += nest_entries.count - 1
           end

--- a/test/test_kramdown_list.rb
+++ b/test/test_kramdown_list.rb
@@ -103,10 +103,10 @@ class TestKramdownList < Minitest::Test
 
     def test_kramdown_list_3
       text = <<-MARKDOWN
-  * level-1
-      * level-3
-    * level-2
-  * level-1
+* level-1
+    * level-3
+  * level-2
+* level-1
       MARKDOWN
       expected = <<-HTML
 <ul>

--- a/test/test_kramdown_list.rb
+++ b/test/test_kramdown_list.rb
@@ -1,0 +1,125 @@
+require 'test_helper'
+
+class TestKramdownList < Minitest::Test
+  def test_kramdown_list_1
+    text = <<-MARKDOWN
+* level-1
+  * level-2
+    * level-3
+      * level-4
+        * level-5
+    MARKDOWN
+    expected = <<-HTML
+<ul>
+  <li>level-1
+    <ul>
+      <li>level-2
+        <ul>
+          <li>level-3
+            <ul>
+              <li>level-4
+                <ul>
+                  <li>level-5</li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+</ul>
+    HTML
+
+    assert_equal(expected, Kramdown::Document.new(text).to_html)
+  end
+
+  def test_kramdown_list_2
+    text = <<-MARKDOWN
+* level-1
+    * level-3
+  * level-2
+      * level-4
+        * level-5
+    MARKDOWN
+    expected = <<-HTML
+<ul>
+  <li>level-1
+    <ul>
+      <li>level-3</li>
+      <li>level-2
+        <ul>
+          <li>level-4
+            <ul>
+              <li>level-5</li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+</ul>
+    HTML
+
+    assert_equal(expected, Kramdown::Document.new(text).to_html)
+  end
+
+  def test_kramdown_list_3
+    text = <<-MARKDOWN
+      * level-4
+    * level-3
+  * level-2
+* level-1
+    MARKDOWN
+    expected = <<-HTML
+    HTML
+
+    assert_equal(expected, Kramdown::Document.new(text).to_html)
+  end
+
+  def test_kramdown_list_3
+    text = <<-MARKDOWN
+* level-1
+      * level-4
+    * level-3
+  * level-2
+* level-1
+    MARKDOWN
+    expected = <<-HTML
+<ul>
+  <li>level-1
+    * level-4
+    <ul>
+      <li>level-3</li>
+      <li>level-2</li>
+    </ul>
+  </li>
+  <li>level-1</li>
+</ul>
+    HTML
+
+    assert_equal(expected, Kramdown::Document.new(text).to_html)
+  end
+
+    def test_kramdown_list_3
+      text = <<-MARKDOWN
+  * level-1
+      * level-3
+    * level-2
+  * level-1
+      MARKDOWN
+      expected = <<-HTML
+<ul>
+  <li>level-1
+    <ul>
+      <li>level-3</li>
+      <li>level-2</li>
+    </ul>
+  </li>
+  <li>level-1</li>
+</ul>
+      HTML
+
+      assert_equal(expected, Kramdown::Document.new(text).to_html)
+    end
+end

--- a/test/test_various_toc_html.rb
+++ b/test/test_various_toc_html.rb
@@ -73,21 +73,11 @@ class TestVariousTocHtml < Minitest::Test
     doc = Nokogiri::HTML(parser.toc)
     expected = <<-HTML
 <ul class="section-nav">
-<ul>
-<ul>
-<ul>
-<ul>
-<ul>
 <li class="toc-entry toc-h6"><a href="#h6">h6</a></li>
-</ul>
 <li class="toc-entry toc-h5"><a href="#h5">h5</a></li>
-</ul>
 <li class="toc-entry toc-h4"><a href="#h4">h4</a></li>
-</ul>
 <li class="toc-entry toc-h3"><a href="#h3">h3</a></li>
-</ul>
 <li class="toc-entry toc-h2"><a href="#h2">h2</a></li>
-</ul>
 <li class="toc-entry toc-h1"><a href="#h1">h1</a></li>
 </ul>
     HTML

--- a/test/test_various_toc_html.rb
+++ b/test/test_various_toc_html.rb
@@ -24,8 +24,8 @@ class TestVariousTocHtml < Minitest::Test
   HTML
 
   def test_nested_toc
-    @parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_1)
-    doc = Nokogiri::HTML(@parser.toc)
+    parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_1)
+    doc = Nokogiri::HTML(parser.toc)
     assert_equal(doc.css('ul.section-nav').to_s, <<-HTML
 <ul class="section-nav">
 <li class="toc-entry toc-h1">
@@ -45,8 +45,8 @@ class TestVariousTocHtml < Minitest::Test
   end
 
   def test_complex_nested_toc
-    @parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_2)
-    doc = Nokogiri::HTML(@parser.toc)
+    parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_2)
+    doc = Nokogiri::HTML(parser.toc)
     assert_equal(doc.css('ul.section-nav').to_s, <<-HTML
 <ul class="section-nav">
 <li class="toc-entry toc-h1">
@@ -69,8 +69,8 @@ class TestVariousTocHtml < Minitest::Test
   end
 
   def test_decremental_headings
-    @parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_3)
-    doc = Nokogiri::HTML(@parser.toc)
+    parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_3)
+    doc = Nokogiri::HTML(parser.toc)
     assert_equal(doc.css('ul.section-nav').to_s, <<-HTML
 <ul class="section-nav">
 <ul>

--- a/test/test_various_toc_html.rb
+++ b/test/test_various_toc_html.rb
@@ -53,9 +53,7 @@ class TestVariousTocHtml < Minitest::Test
 <li class="toc-entry toc-h1">
 <a href="#h1">h1</a>
 <ul>
-<ul>
 <li class="toc-entry toc-h3"><a href="#h3">h3</a></li>
-</ul>
 <li class="toc-entry toc-h2">
 <a href="#h2">h2</a>
 <ul>

--- a/test/test_various_toc_html.rb
+++ b/test/test_various_toc_html.rb
@@ -23,6 +23,14 @@ class TestVariousTocHtml < Minitest::Test
 <h1>h1</h1>
   HTML
 
+  TEST_HTML_4 = <<-HTML
+<h1>h1</h1>
+<h3>h3</h3>
+<h2>h2</h2>
+<h4>h4</h4>
+<h5>h5</h5>
+  HTML
+
   def test_nested_toc
     parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_1)
     doc = Nokogiri::HTML(parser.toc)
@@ -79,6 +87,35 @@ class TestVariousTocHtml < Minitest::Test
 <li class="toc-entry toc-h3"><a href="#h3">h3</a></li>
 <li class="toc-entry toc-h2"><a href="#h2">h2</a></li>
 <li class="toc-entry toc-h1"><a href="#h1">h1</a></li>
+</ul>
+    HTML
+
+    assert_equal(expected, doc.css('ul.section-nav').to_s)
+  end
+
+
+  def test_decremental_headings
+    parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_4)
+    doc = Nokogiri::HTML(parser.toc)
+    expected = <<-HTML
+<ul class="section-nav">
+<li class="toc-entry toc-h1">
+<a href="#h1">h1</a>
+<ul>
+<li class="toc-entry toc-h3"><a href="#h3">h3</a></li>
+<li class="toc-entry toc-h2">
+<a href="#h2">h2</a>
+<ul>
+<li class="toc-entry toc-h4">
+<a href="#h4">h4</a>
+<ul>
+<li class="toc-entry toc-h5"><a href="#h5">h5</a></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</li>
 </ul>
     HTML
 

--- a/test/test_various_toc_html.rb
+++ b/test/test_various_toc_html.rb
@@ -26,7 +26,7 @@ class TestVariousTocHtml < Minitest::Test
   def test_nested_toc
     parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_1)
     doc = Nokogiri::HTML(parser.toc)
-    assert_equal(doc.css('ul.section-nav').to_s, <<-HTML
+    expected = <<-HTML
 <ul class="section-nav">
 <li class="toc-entry toc-h1">
 <a href="#h1">h1</a>
@@ -41,13 +41,14 @@ class TestVariousTocHtml < Minitest::Test
 </li>
 </ul>
     HTML
-    )
+
+    assert_equal(expected, doc.css('ul.section-nav').to_s)
   end
 
   def test_complex_nested_toc
     parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_2)
     doc = Nokogiri::HTML(parser.toc)
-    assert_equal(doc.css('ul.section-nav').to_s, <<-HTML
+    expected = <<-HTML
 <ul class="section-nav">
 <li class="toc-entry toc-h1">
 <a href="#h1">h1</a>
@@ -65,13 +66,14 @@ class TestVariousTocHtml < Minitest::Test
 </li>
 </ul>
     HTML
-    )
+
+    assert_equal(expected, doc.css('ul.section-nav').to_s)
   end
 
   def test_decremental_headings
     parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_3)
     doc = Nokogiri::HTML(parser.toc)
-    assert_equal(doc.css('ul.section-nav').to_s, <<-HTML
+    expected = <<-HTML
 <ul class="section-nav">
 <ul>
 <ul>
@@ -91,6 +93,7 @@ class TestVariousTocHtml < Minitest::Test
 <li class="toc-entry toc-h1"><a href="#h1">h1</a></li>
 </ul>
     HTML
-    )
+
+    assert_equal(expected, doc.css('ul.section-nav').to_s)
   end
 end


### PR DESCRIPTION
Issue #25 

## Changes

- Add last_ul_used arguments to fix invalid nested `<ul>` tag
- Add more complex toc test
- Add [kramdown](https://github.com/gettalong/kramdown) list parser test for reference 

## Parser logic change overview

```html
<h6>h6</h6>
<h5>h5</h5>
<h4>h4</h4>
<h3>h3</h3>
<h2>h2</h2>
<h1>h1</h1>
```

This headings generate following TOC.

```html
<ul class="section-nav">
<li class="toc-entry toc-h6"><a href="#h6">h6</a></li>
<li class="toc-entry toc-h5"><a href="#h5">h5</a></li>
<li class="toc-entry toc-h4"><a href="#h4">h4</a></li>
<li class="toc-entry toc-h3"><a href="#h3">h3</a></li>
<li class="toc-entry toc-h2"><a href="#h2">h2</a></li>
<li class="toc-entry toc-h1"><a href="#h1">h1</a></li>
</ul>
```

---

```html
<h1>h1</h1>
<h3>h3</h3>
<h2>h2</h2>
<h4>h4</h4>
<h5>h5</h5>
```

This headings generate following TOC.

```html
<ul class="section-nav">
<li class="toc-entry toc-h1">
<a href="#h1">h1</a>
<ul>
<li class="toc-entry toc-h3"><a href="#h3">h3</a></li>
<li class="toc-entry toc-h2">
<a href="#h2">h2</a>
<ul>
<li class="toc-entry toc-h4">
<a href="#h4">h4</a>
<ul>
<li class="toc-entry toc-h5"><a href="#h5">h5</a></li>
</ul>
</li>
</ul>
</li>
</ul>
</li>
</ul>
```