### PR TITLE
TOC configuration: configurable heading min_level and max_level

### DIFF
--- a/lib/jekyll-toc.rb
+++ b/lib/jekyll-toc.rb
@@ -2,6 +2,13 @@ require 'nokogiri'
 require 'table_of_contents/parser'
 
 module Jekyll
+  class TocTag < Liquid::Tag
+    def render(context)
+      content_html = context.registers[:page].content
+      ::Jekyll::TableOfContents::Parser.new(content_html).build_toc
+    end
+  end
+
   module TableOfContentsFilter
     def toc_only(html)
       return html unless toc_enabled?
@@ -31,3 +38,4 @@ module Jekyll
 end
 
 Liquid::Template.register_filter(Jekyll::TableOfContentsFilter)
+Liquid::Template.register_tag('toc', Jekyll::TocTag)

--- a/lib/jekyll-toc.rb
+++ b/lib/jekyll-toc.rb
@@ -4,24 +4,25 @@ require 'table_of_contents/parser'
 module Jekyll
   module TableOfContentsFilter
     def toc_only(html)
-      return html unless page['toc']
-
+      return html unless toc_enabled?
       ::Jekyll::TableOfContents::Parser.new(html).build_toc
     end
 
     def inject_anchors(html)
-      return html unless page['toc']
-
+      return html unless toc_enabled?
       ::Jekyll::TableOfContents::Parser.new(html).inject_anchors_into_html
     end
 
     def toc(html)
-      return html unless page['toc']
-
+      return html unless toc_enabled?
       ::Jekyll::TableOfContents::Parser.new(html).toc
     end
 
     private
+
+    def toc_enabled?
+      page['toc'] == true
+    end
 
     def page
       @context.registers[:page]

--- a/lib/jekyll-toc.rb
+++ b/lib/jekyll-toc.rb
@@ -4,6 +4,7 @@ require 'table_of_contents/parser'
 module Jekyll
   class TocTag < Liquid::Tag
     def render(context)
+      return unless context.registers[:page]['toc'] == true
       content_html = context.registers[:page].content
       ::Jekyll::TableOfContents::Parser.new(content_html).build_toc
     end

--- a/lib/jekyll-toc.rb
+++ b/lib/jekyll-toc.rb
@@ -13,27 +13,27 @@ module Jekyll
   module TableOfContentsFilter
     def toc_only(html)
       return html unless toc_enabled?
-      ::Jekyll::TableOfContents::Parser.new(html).build_toc
+      ::Jekyll::TableOfContents::Parser.new(html, toc_config).build_toc
     end
 
     def inject_anchors(html)
       return html unless toc_enabled?
-      ::Jekyll::TableOfContents::Parser.new(html).inject_anchors_into_html
+      ::Jekyll::TableOfContents::Parser.new(html, toc_config).inject_anchors_into_html
     end
 
     def toc(html)
       return html unless toc_enabled?
-      ::Jekyll::TableOfContents::Parser.new(html).toc
+      ::Jekyll::TableOfContents::Parser.new(html, toc_config).toc
     end
 
     private
 
     def toc_enabled?
-      page['toc'] == true
+      @context.registers[:page]['toc'] == true
     end
 
-    def page
-      @context.registers[:page]
+    def toc_config
+      @context.registers[:site].config["toc"]
     end
   end
 end

--- a/lib/jekyll-toc.rb
+++ b/lib/jekyll-toc.rb
@@ -39,4 +39,4 @@ module Jekyll
 end
 
 Liquid::Template.register_filter(Jekyll::TableOfContentsFilter)
-Liquid::Template.register_tag('toc', Jekyll::TocTag)
+# Liquid::Template.register_tag('toc', Jekyll::TocTag) # will be enabled at v1.0

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -4,8 +4,15 @@ module Jekyll
     class Parser
       PUNCTUATION_REGEXP = /[^\p{Word}\- ]/u
 
-      def initialize(html)
+      DEFAULT_CONFIG = {
+        "min_level" => 1,
+        "max_level" => 6,
+      }
+
+      def initialize(html, options = {})
         @doc = Nokogiri::HTML::DocumentFragment.parse(html)
+        options = DEFAULT_CONFIG.merge(options)
+        @toc_levels = options["min_level"]..options["max_level"]
         @entries = parse_content
       end
 
@@ -34,7 +41,7 @@ module Jekyll
         headers = Hash.new(0)
 
         # TODO: Use kramdown auto ids
-        @doc.css('h1, h2, h3, h4, h5, h6').each do |node|
+        @doc.css(toc_headings).each do |node|
           text = node.text
           id = text.downcase
           id.gsub!(PUNCTUATION_REGEXP, '') # remove punctuation
@@ -104,6 +111,10 @@ module Jekyll
           break nest_entries if entry[:h_num] == min_h_num
           nest_entries << entry
         end
+      end
+
+      def toc_headings
+        @toc_levels.map { |level| "h#{level}" }.join(",")
       end
     end
   end

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -33,6 +33,7 @@ module Jekyll
         entries = []
         headers = Hash.new(0)
 
+        # TODO: Use kramdown auto ids
         @doc.css('h1, h2, h3, h4, h5, h6').each do |node|
           text = node.text
           id = text.downcase

--- a/test/test_kramdown_list.rb
+++ b/test/test_kramdown_list.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class TestKramdownList < Minitest::Test
   # NOTE: kramdown automatically injects `id` attribute
+  # TODO: test Japanese heading
   def test_kramdown_heading
     text = <<-MARKDOWN
 # h1

--- a/test/test_kramdown_list.rb
+++ b/test/test_kramdown_list.rb
@@ -72,12 +72,15 @@ class TestKramdownList < Minitest::Test
 * level-1
     MARKDOWN
     expected = <<-HTML
+<pre><code>  * level-4
+* level-3   * level-2 * level-1
+</code></pre>
     HTML
 
     assert_equal(expected, Kramdown::Document.new(text).to_html)
   end
 
-  def test_kramdown_list_3
+  def test_kramdown_list_4
     text = <<-MARKDOWN
 * level-1
       * level-4
@@ -101,7 +104,7 @@ class TestKramdownList < Minitest::Test
     assert_equal(expected, Kramdown::Document.new(text).to_html)
   end
 
-    def test_kramdown_list_3
+    def test_kramdown_list_5
       text = <<-MARKDOWN
 * level-1
     * level-3

--- a/test/test_kramdown_list.rb
+++ b/test/test_kramdown_list.rb
@@ -1,6 +1,22 @@
 require 'test_helper'
 
 class TestKramdownList < Minitest::Test
+  # NOTE: kramdown automatically injects `id` attribute
+  def test_kramdown_heading
+    text = <<-MARKDOWN
+# h1
+
+## h2
+    MARKDOWN
+    expected = <<-HTML
+<h1 id="h1">h1</h1>
+
+<h2 id=\"h2\">h2</h2>
+    HTML
+
+    assert_equal(expected, Kramdown::Document.new(text).to_html)
+  end
+
   def test_kramdown_list_1
     text = <<-MARKDOWN
 * level-1

--- a/test/test_various_toc_html.rb
+++ b/test/test_various_toc_html.rb
@@ -76,7 +76,7 @@ class TestVariousTocHtml < Minitest::Test
     assert_equal(expected, doc.css('ul.section-nav').to_s)
   end
 
-  def test_decremental_headings
+  def test_decremental_headings1
     parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_3)
     doc = Nokogiri::HTML(parser.toc)
     expected = <<-HTML
@@ -94,7 +94,7 @@ class TestVariousTocHtml < Minitest::Test
   end
 
 
-  def test_decremental_headings
+  def test_decremental_headings2
     parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_4)
     doc = Nokogiri::HTML(parser.toc)
     expected = <<-HTML

--- a/test/test_various_toc_html.rb
+++ b/test/test_various_toc_html.rb
@@ -53,6 +53,18 @@ class TestVariousTocHtml < Minitest::Test
     assert_equal(expected, doc.css('ul.section-nav').to_s)
   end
 
+  def test_nested_toc_with_min_and_max
+    parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_1, { "min_level" => 2, "max_level" => 5 })
+    doc = Nokogiri::HTML(parser.toc)
+    expected = <<-HTML
+<ul class="section-nav">
+<li class="toc-entry toc-h3"><a href="#h3">h3</a></li>
+</ul>
+    HTML
+
+    assert_equal(expected, doc.css('ul.section-nav').to_s)
+  end
+
   def test_complex_nested_toc
     parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_2)
     doc = Nokogiri::HTML(parser.toc)


### PR DESCRIPTION
Issue #31

jekyll-toc is now configurable by `_config.yml`!

You can configure heading min level and max level. (default heading levels are `h1` to `h6`)

## jekyll-toc configuration

`_config.yml`:

```yml
toc:
  min_level: 1
  max_level: 5
```

## TODO

- [x] Test