### PR TITLE
Fix toc_config being nil

### DIFF
--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -11,7 +11,7 @@ module Jekyll
 
       def initialize(html, options = {})
         @doc = Nokogiri::HTML::DocumentFragment.parse(html)
-        options = DEFAULT_CONFIG.merge(options)
+        options = options.nil? ? DEFAULT_CONFIG.clone : DEFAULT_CONFIG.merge(options)
         @toc_levels = options["min_level"]..options["max_level"]
         @entries = parse_content
       end


### PR DESCRIPTION
If _config.yml does not contain a `toc` section, `toc_config` will return nil, which breaks the parser. This is a potential fix.