### PR TITLE
better cleaning of urls and enable local configs

### DIFF
--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -2,7 +2,7 @@ module Jekyll
   module TableOfContents
     # Parse html contents and generate table of contents
     class Parser
-      PUNCTUATION_REGEXP = /[^\p{Word}\- ]/u
+      PUNCTUATION_REGEXP = /[^\p{Word}\-\/ ]/u
 
       DEFAULT_CONFIG = {
         "min_level" => 1,

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -2,7 +2,7 @@ module Jekyll
   module TableOfContents
     # Parse html contents and generate table of contents
     class Parser
-      PUNCTUATION_REGEXP = /[^\p{Word}\-\/ ]/u
+      PUNCTUATION_REGEXP = /[^\p{Word}\- ]/u
 
       DEFAULT_CONFIG = {
         "min_level" => 1,
@@ -44,8 +44,11 @@ module Jekyll
         @doc.css(toc_headings).each do |node|
           text = node.text
           id = text.downcase
-          id.gsub!(PUNCTUATION_REGEXP, '') # remove punctuation
+          id.gsub!(PUNCTUATION_REGEXP, ' ') # replace punctuation with spaces
+          id.gsub!(/\s+/,' ') # in case there were two or more special characters
           id.gsub!(' ', '-') # replace spaces with dash
+          id.gsub!(/-+/, '-') # in case there were two or more dashes
+          id.chomp!('-') # not at the end
 
           uniq = headers[id] > 0 ? "-#{headers[id]}" : ''
           headers[id] += 1


### PR DESCRIPTION
1) make the generated urls for anchors be more like slugs (e.g. "/" also becomes a dash)
2) I frequently want some posts to have more extensive TOCs than others. I've changed the rendering and the filtering so that you can also define a front matter as follows, and these local configurations are only valid for the current post:

```
---
layout: page
header: no
title: "Post title here"
toc: 
    max_level: 3
---
post contents here.
for this post only, the toc configs will have "max_level" => 3, so that TOCs up to header-3 will be printed.
```
