### PR TITLE
Add support for no_toc

### DIFF
--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -57,7 +57,7 @@ module Jekyll
             uniq: uniq,
             text: text,
             node_name: node.name,
-            no_toc: node.attribute('class')&.value&.include?('no_toc'),
+            no_toc: node.attribute('class') && node.attribute('class').value.include?('no_toc'),
             content_node: header_content,
             h_num: node.name.delete('h').to_i
           }

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -57,6 +57,7 @@ module Jekyll
             uniq: uniq,
             text: text,
             node_name: node.name,
+            no_toc: node.attribute('class')&.value&.include?('no_toc'),
             content_node: header_content,
             h_num: node.name.delete('h').to_i
           }
@@ -73,7 +74,9 @@ module Jekyll
 
         while i < entries.count
           entry = entries[i]
-          if entry[:h_num] == min_h_num
+          if entry[:no_toc]
+            # Do nothing / skip entry
+          elsif entry[:h_num] == min_h_num
             # If the current entry should not be indented in the list, add the entry to the list
             toc_list << %(<li class="toc-entry toc-#{entry[:node_name]}"><a href="##{entry[:id]}#{entry[:uniq]}">#{entry[:text]}</a>)
             # If the next entry should be indented in the list, generate a sublist

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module JekyllToc
-  VERSION = '0.6.0'.freeze
+  VERSION = '0.7.0-dev.1'.freeze
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,6 +12,7 @@ SIMPLE_HTML = <<-HTML.freeze
   <h4>Simple H4</h4>
   <h5>Simple H5</h5>
   <h6>Simple H6</h6>
+  <h1 class="no_toc">No-toc H1</h1>
 HTML
 
 module TestHelpers


### PR DESCRIPTION
Fixes #37 by ignoring heading entries with class "no_toc" (the same class name used by Kramdown's TOC feature).

cc @Sfshaza @filiph @kwalrath 