### PR TITLE
Add an `ignore_within` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,26 @@ toc:
 
 The default level range is `<h1>` to `<h6>`.
 
+### Ignore within
+
+It can be configured to ignore elements within a selector:
+
+```yml
+toc:
+  ignore_within: .exclude
+```
+
+```html
+<h1>h1</h1>
+<div class="exclude">
+  <h2>h2</h2>
+  <h3>h3</h3>
+</div>
+<h4>h4</h4>
+```
+
+Which would result in only the `<h1>` & `<h4>` within the example being included in the TOC.
+
 ### CSS Styling
 
 The toc can be modified with CSS. The sample CSS is the following.

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -14,7 +14,8 @@ module Jekyll
       def initialize(html, options = {})
         @doc = Nokogiri::HTML::DocumentFragment.parse(html)
         options = generate_option_hash(options)
-        @toc_levels = options['min_level']..options['max_level']
+        @toc_levels = options["min_level"]..options["max_level"]
+        @ignore_within = options["ignore_within"]
         @entries = parse_content
       end
 
@@ -41,6 +42,10 @@ module Jekyll
       def parse_content
         entries = []
         headers = Hash.new(0)
+
+        if @ignore_within
+          @doc.css(@ignore_within).remove
+        end
 
         # TODO: Use kramdown auto ids
         @doc.css(toc_headings).reject { |n| n.classes.include?('no_toc') }.each do |node|

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module JekyllToc
-  VERSION = '0.7.1'.freeze
+  VERSION = '0.7.2'.freeze
 end

--- a/test/test_various_toc_html.rb
+++ b/test/test_various_toc_html.rb
@@ -247,4 +247,40 @@ class TestVariousTocHtml < Minitest::Test
 
     assert_equal(expected, actual)
   end
+
+TEST_HTML_IGNORE = <<-HTML
+<h1>h1</h1>
+<div class="exclude">
+<h2>h2</h2>
+</div>
+<h3>h3</h3>
+<div class="exclude">
+<h4>h4</h4>
+<h4>h5</h4>
+</div>
+<h6>h6</h6>
+HTML
+
+  def test_nested_toc_with_ignore_within_option
+    parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_IGNORE, { "ignore_within" => '.exclude'})
+    doc = Nokogiri::HTML(parser.toc)
+    expected = <<-HTML
+<ul class="section-nav">
+<li class="toc-entry toc-h1">
+<a href="#h1">h1</a>
+<ul>
+<li class="toc-entry toc-h3">
+<a href="#h3">h3</a>
+<ul>
+<li class="toc-entry toc-h6"><a href="#h6">h6</a></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+    HTML
+    actual = doc.css('ul.section-nav').to_s
+
+    assert_equal(expected, actual)
+  end
 end


### PR DESCRIPTION
Adds an `ignore_within` option to provide a selector to ignore elements within. So given the following HTML:

```html
<h1>h1</h1>
<div class="exclude">
  <h2>h2</h2>
  <h3>h3</h3>
</div>
<h4>h4</h4>
```

With the configuration:
```yml
toc:
  ignore_within: .exclude
```

All headings within the `.exclude` selector will be ignored.