### PR TITLE
Add `no_toc_section` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [Generated HTML](#generated-html)
 - [Customization](#customization)
   - [Skip TOC](#skip-toc)
+  - [Skip TOC Section](#skip-toc-section)
   - [TOC levels](#toc-levels)
   - [CSS Styling](#css-styling)
 
@@ -121,9 +122,29 @@ The heading is ignored in the toc when you add `no_toc` to the class.
 <h2>h2</h2>
 ```
 
+#### Skip TOC Section
+
+It can be configured to ignore elements within a selector:
+
+```yml
+toc:
+  no_toc_section_class: no_toc_within # default: no_toc_section
+```
+
+```html
+<h1>h1</h1>
+<div class="no_toc_within">
+  <h2>h2</h2>
+  <h3>h3</h3>
+</div>
+<h4>h4</h4>
+```
+
+Which would result in only the `<h1>` & `<h4>` within the example being included in the TOC.
+
 #### TOC levels
 
-The TOC levels can be configured on `_config.yml`.
+The toc levels can be configured on `_config.yml`.
 
 ```yml
 toc:
@@ -132,26 +153,6 @@ toc:
 ```
 
 The default level range is `<h1>` to `<h6>`.
-
-#### Ignore within
-
-It can be configured to ignore elements within a selector:
-
-```yml
-toc:
-  ignore_within: .exclude
-```
-
-```html
-<h1>h1</h1>
-<div class="exclude">
-  <h2>h2</h2>
-  <h3>h3</h3>
-</div>
-<h4>h4</h4>
-```
-
-Which would result in only the `<h1>` & `<h4>` within the example being included in the TOC.
 
 #### CSS Styling
 

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -50,14 +50,10 @@ module Jekyll
         # TODO: Use kramdown auto ids
         @doc.css(toc_headings).reject { |n| n.classes.include?('no_toc') }.each do |node|
           text = node.text
-          id = if node.attribute('id')
-            node.attribute('id')
-          else
-            text
-              .downcase
-              .gsub(PUNCTUATION_REGEXP, '') # remove punctuation
-              .tr(' ', '-') # replace spaces with dash
-          end
+          id = node.attribute('id') || text
+               .downcase
+               .gsub(PUNCTUATION_REGEXP, '') # remove punctuation
+               .tr(' ', '-') # replace spaces with dash
 
           uniq = headers[id] > 0 ? "-#{headers[id]}" : ''
           headers[id] += 1
@@ -117,6 +113,7 @@ module Jekyll
       def get_nest_entries(entries, min_h_num)
         entries.inject([]) do |nest_entries, entry|
           break nest_entries if entry[:h_num] == min_h_num
+
           nest_entries << entry
         end
       end

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -19,6 +19,10 @@ module Jekyll
         @entries = parse_content
       end
 
+      def toc
+        build_toc + inject_anchors_into_html
+      end
+
       def build_toc
         %(<ul class="section-nav">\n#{build_toc_list(@entries)}</ul>)
       end
@@ -29,10 +33,6 @@ module Jekyll
         end
 
         @doc.inner_html
-      end
-
-      def toc
-        build_toc + inject_anchors_into_html
       end
 
       private

--- a/test/test_various_toc_html.rb
+++ b/test/test_various_toc_html.rb
@@ -86,7 +86,7 @@ class TestVariousTocHtml < Minitest::Test
   end
 
   def test_nested_toc_with_min_and_max
-    parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_1, { "min_level" => 2, "max_level" => 5 })
+    parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_1, { 'min_level' => 2, 'max_level' => 5 })
     doc = Nokogiri::HTML(parser.toc)
     expected = <<-HTML
 <ul class="section-nav">
@@ -248,21 +248,17 @@ class TestVariousTocHtml < Minitest::Test
     assert_equal(expected, actual)
   end
 
-TEST_HTML_IGNORE = <<-HTML
+  TEST_HTML_IGNORE = <<-HTML
 <h1>h1</h1>
-<div class="exclude">
+<div class="no_toc_section">
 <h2>h2</h2>
 </div>
 <h3>h3</h3>
-<div class="exclude">
-<h4>h4</h4>
-<h4>h5</h4>
-</div>
 <h6>h6</h6>
-HTML
+  HTML
 
-  def test_nested_toc_with_ignore_within_option
-    parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_IGNORE, { "ignore_within" => '.exclude'})
+  def test_nested_toc_with_no_toc_section_class
+    parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_IGNORE)
     doc = Nokogiri::HTML(parser.toc)
     expected = <<-HTML
 <ul class="section-nav">
@@ -280,8 +276,56 @@ HTML
 </ul>
     HTML
     actual = doc.css('ul.section-nav').to_s
-
     assert_equal(expected, actual)
+
+    html = parser.inject_anchors_into_html
+    assert_match(%r{<h1>.+</h1>}m, html)
+    assert_match(%r{<h3>.+</h3>}m, html)
+    assert_match(%r{<h6>.+</h6>}m, html)
+    assert_includes(html, '<h2>h2</h2>')
+  end
+
+  TEST_HTML_IGNORE_2 = <<-HTML
+<h1>h1</h1>
+<div class="exclude">
+<h2>h2</h2>
+</div>
+<h3>h3</h3>
+<div class="exclude">
+<h4>h4</h4>
+<h5>h5</h5>
+</div>
+<h6>h6</h6>
+  HTML
+
+  def test_nested_toc_with_no_toc_section_class_option
+    parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_IGNORE_2, { 'no_toc_section_class' => 'exclude' })
+    doc = Nokogiri::HTML(parser.toc)
+    expected = <<-HTML
+<ul class="section-nav">
+<li class="toc-entry toc-h1">
+<a href="#h1">h1</a>
+<ul>
+<li class="toc-entry toc-h3">
+<a href="#h3">h3</a>
+<ul>
+<li class="toc-entry toc-h6"><a href="#h6">h6</a></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+    HTML
+    actual = doc.css('ul.section-nav').to_s
+    assert_equal(expected, actual)
+
+    html = parser.inject_anchors_into_html
+    assert_match(%r{<h1>.+</h1>}m, html)
+    assert_match(%r{<h3>.+</h3>}m, html)
+    assert_match(%r{<h6>.+</h6>}m, html)
+    assert_includes(html, '<h2>h2</h2>')
+    assert_includes(html, '<h4>h4</h4>')
+    assert_includes(html, '<h5>h5</h5>')
   end
 
   TEST_EXPLICIT_ID = <<-HTML
@@ -291,7 +335,7 @@ HTML
   HTML
 
   def test_toc_with_explicit_id
-    parser = Jekyll::TableOfContents::Parser.new(TEST_EXPLICIT_ID, { "ignore_within" => '.exclude'})
+    parser = Jekyll::TableOfContents::Parser.new(TEST_EXPLICIT_ID)
     doc = Nokogiri::HTML(parser.toc)
     expected = <<-HTML
 <ul class="section-nav">
@@ -300,7 +344,12 @@ HTML
 <li class="toc-entry toc-h1"><a href="#third">h3</a></li>
 </ul>
     HTML
+    actual = doc.css('ul.section-nav').to_s
+    assert_equal(expected, actual)
 
-    assert_equal(expected, doc.css('ul.section-nav').to_s)
+    html = parser.inject_anchors_into_html
+    assert_includes(html, %(<a id="h1" class="anchor" href="#h1" aria-hidden="true">))
+    assert_includes(html, %(<a id="second" class="anchor" href="#second" aria-hidden="true">))
+    assert_includes(html, %(<a id="third" class="anchor" href="#third" aria-hidden="true">))
   end
 end


### PR DESCRIPTION
Follow up to #53 

- Change option key name: ignore_within => no_toc_section_class
- Update README
- Fix issue: Elements inside `no_toc_section` are lost