### PR TITLE
Use explicit ID attribute if present

### DIFF
--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -50,9 +50,14 @@ module Jekyll
         # TODO: Use kramdown auto ids
         @doc.css(toc_headings).reject { |n| n.classes.include?('no_toc') }.each do |node|
           text = node.text
-          id = text.downcase
-          id.gsub!(PUNCTUATION_REGEXP, '') # remove punctuation
-          id.tr!(' ', '-') # replace spaces with dash
+          id = if node.attribute('id')
+            node.attribute('id')
+          else
+            text
+              .downcase
+              .gsub(PUNCTUATION_REGEXP, '') # remove punctuation
+              .tr(' ', '-') # replace spaces with dash
+          end
 
           uniq = headers[id] > 0 ? "-#{headers[id]}" : ''
           headers[id] += 1

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module JekyllToc
-  VERSION = '0.8.0.beta1'.freeze
+  VERSION = '0.8.0.beta2'.freeze
 end

--- a/test/test_various_toc_html.rb
+++ b/test/test_various_toc_html.rb
@@ -283,4 +283,24 @@ HTML
 
     assert_equal(expected, actual)
   end
+
+  TEST_EXPLICIT_ID = <<-HTML
+<h1>h1</h1>
+<h1 id="second">h2</h1>
+<h1 id="third">h3</h1>
+  HTML
+
+  def test_toc_with_explicit_id
+    parser = Jekyll::TableOfContents::Parser.new(TEST_EXPLICIT_ID, { "ignore_within" => '.exclude'})
+    doc = Nokogiri::HTML(parser.toc)
+    expected = <<-HTML
+<ul class="section-nav">
+<li class="toc-entry toc-h1"><a href="#h1">h1</a></li>
+<li class="toc-entry toc-h1"><a href="#second">h2</a></li>
+<li class="toc-entry toc-h1"><a href="#third">h3</a></li>
+</ul>
+    HTML
+
+    assert_equal(expected, doc.css('ul.section-nav').to_s)
+  end
 end


### PR DESCRIPTION
Use the ID of the heading element as the anchor if it is present.