### PR TITLE
Add option to enable toc by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ toc: true
 ---
 ```
 
+Or set `enable_by_default: true` in `_config.yml` to enable for all posts.
+
+```yml
+toc:
+  enable_by_default: true
+```
+
+With this option, setting `toc: false` in a post's frontmatter to disable the TOC on that post.
+
 ## Usage
 
 There are three Liquid filters, which can be applied to HTML content,

--- a/lib/jekyll-toc.rb
+++ b/lib/jekyll-toc.rb
@@ -41,7 +41,7 @@ module Jekyll
 
       if enabled_on_page == nil
         return enabled_site_wide
-      else:
+      else
         return page_specific
       end
     end

--- a/lib/jekyll-toc.rb
+++ b/lib/jekyll-toc.rb
@@ -16,7 +16,7 @@ module Jekyll
   # Jekyll Table of Contents filter plugin
   module TableOfContentsFilter
     def toc_only(html)
-      return html unless toc_enabled?
+      return '' unless toc_enabled?
 
       ::Jekyll::TableOfContents::Parser.new(html, toc_config).build_toc
     end
@@ -36,7 +36,14 @@ module Jekyll
     private
 
     def toc_enabled?
-      @context.registers[:page]['toc'] == true
+      enabled_site_wide = @context.registers[:site].config['toc']['enable_by_default'] == true
+      enabled_on_page = @context.registers[:page]['toc']
+
+      if enabled_on_page == nil
+        return enabled_site_wide
+      else:
+        return page_specific
+      end
     end
 
     def toc_config


### PR DESCRIPTION
Perhaps it's only me, but I wanted a way to globally enable tables of contents and merely override it on a page-by-page basis. This PR adds an option for that, `enable_by_default`.

This PR also makes `toc_only` return nothing when toc is disabled. This might be
a more controversial change (which perhaps should be in a different PR), but I can't really think of a case where the previous behavior would be desired. I also realize this probably breaks some tests. Unfortunately, when I went to look, a whole bunch of tests seemed to be failing even on master. I recognize that it's a bit poor form to submit a PR without updating the tests, but I'm not too sure what's going on there (plus I'm not familiar with ruby at all).