### PR TITLE
Liquid::Template.register_tag 'toc'

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,26 @@ This filter places the TOC directly above the content.
 
 If you'd like separated TOC and content, you can use `toc_only` and `inject_anchors` filters.
 
-#### `toc_only` filter
+#### ~~`toc_only` filter~~
+
+⚠️ Please use `{% toc %}` instead of `{{ contents | toc_only }}`.
 
 Generates the TOC itself as described [below](#generated-html).
 Mostly useful in cases where the TOC should _not_ be placed immediately
 above the content but at some other place of the page, i.e. an aside.
+
+#### toc tag
+
+```html
+<div>
+  <div id="table-of-contents">
+    {% toc %}
+  </div>
+  <div id="markdown-content">
+    {{ content }}
+  </div>
+</div>
+```
 
 #### `inject_anchors` filter
 
@@ -77,7 +92,7 @@ Injects HTML anchors into the content without actually outputting the TOC itself
 They are of the form:
 
 ```html
-<a id="heading11" class="anchor" href="#heading1-1" aria-hidden="true">
+<a class="anchor" href="#heading1-1" aria-hidden="true">
   <span class="octicon octicon-link"></span>
 </a>
 ```

--- a/lib/jekyll-toc.rb
+++ b/lib/jekyll-toc.rb
@@ -9,7 +9,7 @@ module Jekyll
   class TocTag < Liquid::Tag
     def render(context)
       return '' unless context.registers[:page]['toc']
-  
+
       content_html = context.registers[:page].content
       ::Jekyll::TableOfContents::Parser.new(content_html).build_toc
     end
@@ -18,8 +18,8 @@ module Jekyll
   # Jekyll Table of Contents filter plugin
   module TableOfContentsFilter
     def toc_only(html)
-      Jekyll.logger.warn 'Deprecation: toc_only filter is deprecated and will be remove in jekyll-toc 1.0.',
-        'Use `{% toc %}` instead of {{ contents | toc_only }}`.'
+      Jekyll.logger.warn 'Deprecation: toc_only filter is deprecated and will be remove in jekyll-toc v1.0.',
+                         'Use `{% toc %}` instead of {{ contents | toc_only }}`.'
       return '' unless toc_enabled?
 
       ::Jekyll::TableOfContents::Parser.new(html, toc_config).build_toc

--- a/lib/jekyll-toc.rb
+++ b/lib/jekyll-toc.rb
@@ -5,6 +5,7 @@ require 'table_of_contents/configuration'
 require 'table_of_contents/parser'
 
 module Jekyll
+  # toc tag for Jekyll
   class TocTag < Liquid::Tag
     def render(context)
       return '' unless context.registers[:page]['toc']
@@ -17,6 +18,8 @@ module Jekyll
   # Jekyll Table of Contents filter plugin
   module TableOfContentsFilter
     def toc_only(html)
+      Jekyll.logger.warn 'Deprecation: toc_only filter is deprecated and will be remove in jekyll-toc 1.0.',
+        'Use `{% toc %}` instead of {{ contents | toc_only }}`.'
       return '' unless toc_enabled?
 
       ::Jekyll::TableOfContents::Parser.new(html, toc_config).build_toc

--- a/lib/jekyll-toc.rb
+++ b/lib/jekyll-toc.rb
@@ -5,14 +5,14 @@ require 'table_of_contents/configuration'
 require 'table_of_contents/parser'
 
 module Jekyll
-  # class TocTag < Liquid::Tag
-  #   def render(context)
-  #     return unless context.registers[:page]['toc']
-  #
-  #     content_html = context.registers[:page].content
-  #     ::Jekyll::TableOfContents::Parser.new(content_html).build_toc
-  #   end
-  # end
+  class TocTag < Liquid::Tag
+    def render(context)
+      return '' unless context.registers[:page]['toc']
+  
+      content_html = context.registers[:page].content
+      ::Jekyll::TableOfContents::Parser.new(content_html).build_toc
+    end
+  end
 
   # Jekyll Table of Contents filter plugin
   module TableOfContentsFilter
@@ -47,4 +47,4 @@ module Jekyll
 end
 
 Liquid::Template.register_filter(Jekyll::TableOfContentsFilter)
-# Liquid::Template.register_tag('toc', Jekyll::TocTag) # will be enabled at v1.0
+Liquid::Template.register_tag('toc', Jekyll::TocTag) # will be enabled at v1.0

--- a/lib/jekyll-toc.rb
+++ b/lib/jekyll-toc.rb
@@ -19,7 +19,7 @@ module Jekyll
   module TableOfContentsFilter
     def toc_only(html)
       Jekyll.logger.warn 'Deprecation: toc_only filter is deprecated and will be remove in jekyll-toc v1.0.',
-                         'Use `{% toc %}` instead of {{ contents | toc_only }}`.'
+                         'Use `{% toc %}` instead of `{{ contents | toc_only }}`.'
       return '' unless toc_enabled?
 
       ::Jekyll::TableOfContents::Parser.new(html, toc_config).build_toc

--- a/test/test_jekyll-toc.rb
+++ b/test/test_jekyll-toc.rb
@@ -8,8 +8,7 @@ class TestTableOfContentsFilter < Minitest::Test
   DUMMY_HTML = '<div>Dummy HTML Content</div>'
 
   def setup
-    stubbed_context = Struct.new(:registers)
-    @context = stubbed_context.new(page: 'xxx')
+    @context = Struct.new(:registers).new(page: { "toc" => false })
   end
 
   def test_toc_only

--- a/test/test_jekyll-toc.rb
+++ b/test/test_jekyll-toc.rb
@@ -10,7 +10,6 @@ class TestTableOfContentsFilter < Minitest::Test
   def setup
     stubbed_context = Struct.new(:registers)
     @context = stubbed_context.new(page: 'xxx')
-    @context
   end
 
   def test_toc_only

--- a/test/test_toc_tag.rb
+++ b/test/test_toc_tag.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TestTableOfContentsTag < Minitest::Test
+  include Liquid
+
+  def setup
+    stubbed_context = Struct.new(:registers)
+    @context = stubbed_context.new(page: 'xxx')
+  end
+
+  def test_toc_tag
+    tag = Jekyll::TocTag.parse('toc_tag', '', Tokenizer.new(''), ParseContext.new)
+    assert_empty tag.render(@context)
+  end
+end

--- a/test/test_toc_tag.rb
+++ b/test/test_toc_tag.rb
@@ -6,12 +6,19 @@ class TestTableOfContentsTag < Minitest::Test
   include Liquid
 
   def setup
-    stubbed_context = Struct.new(:registers)
-    @context = stubbed_context.new(page: 'xxx')
+    @stubbed_context  = Struct.new(:registers)
+    @stubbed_context2 = Struct.new(:toc, :content)
   end
 
   def test_toc_tag
+    context = @stubbed_context.new(page: @stubbed_context2.new({ 'toc' => false }, '<h1>test</h1>'))
     tag = Jekyll::TocTag.parse('toc_tag', '', Tokenizer.new(''), ParseContext.new)
-    assert_empty tag.render(@context)
+    assert_equal tag.render(context), "<ul class=\"section-nav\">\n<li class=\"toc-entry toc-h1\"><a href=\"#test\">test</a></li>\n</ul>"
+  end
+
+  def test_toc_tag_returns_empty_string
+    context = @stubbed_context.new(page: { 'toc' => false })
+    tag = Jekyll::TocTag.parse('toc_tag', '', Tokenizer.new(''), ParseContext.new)
+    assert_empty tag.render(context)
   end
 end


### PR DESCRIPTION
Issue #38

## Reference 

- [Tags | Jekyll • Simple, blog-aware, static sites](https://jekyllrb.com/docs/plugins/tags/)
- [liquid/tag_unit_test.rb at master · Shopify/liquid](https://github.com/Shopify/liquid/blob/master/test/unit/tag_unit_test.rb)