### PR TITLE
Navigate to top

### DIFF
--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -25,6 +25,9 @@ module Jekyll
 
       def inject_anchors_into_html
         @entries.each do |entry|
+	  # Add id to h-element
+	  entry[:header_parent].set_attribute("id", "#{entry[:id]}")
+		  
           entry[:header_content].add_previous_sibling(
             %(<a class="anchor" href="##{entry[:id]}" aria-hidden="true"><span class="octicon octicon-link"></span></a>)
           )
@@ -57,6 +60,7 @@ module Jekyll
             id: suffix_num.zero? ? id : "#{id}-#{suffix_num}",
             text: CGI.escapeHTML(text),
             node_name: node.name,
+            header_parent: node,
             header_content: node.children.first,
             h_num: node.name.delete('h').to_i
           }

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "erb"
+include ERB::Util
+
 module Jekyll
   module TableOfContents
     # Parse html contents and generate table of contents
@@ -45,6 +48,7 @@ module Jekyll
                .downcase
                .gsub(PUNCTUATION_REGEXP, '') # remove punctuation
                .tr(' ', '-') # replace spaces with dash
+          id = url_encode(id)
 
           suffix_num = headers[id]
           headers[id] += 1

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -37,7 +37,7 @@ module Jekyll
           arrToTop = [ 2, 3 ]
           if arrToTop.include?(entry[:h_num]) then
             entry[:header_content].add_next_sibling(
-              %(<span style="float: right"><a href="#toc" aria-hidden="true">&#x21A5;</a></span>)
+              %(<span style="float: right"><a class="anchor_to_top" href="#toc" aria-hidden="true">&#x21A5;</a></span>)
             )
           end
        end

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -20,7 +20,7 @@ module Jekyll
       end
 
       def build_toc
-        %(<ul class="#{@configuration.list_class}">\n#{build_toc_list(@entries)}</ul>)
+        %(<ul id="toc" class="#{@configuration.list_class}">\n#{build_toc_list(@entries)}</ul>)
       end
 
       def inject_anchors_into_html
@@ -29,9 +29,18 @@ module Jekyll
 	  entry[:header_parent].set_attribute("id", "#{entry[:id]}")
 		  
 	  # Add link icon after text
-	  entry[:header_content].add_next_sibling(%(<a class="anchor" href="##{entry[:id]}" aria-hidden="true">&nbsp;&#128279;</a>)
+	  entry[:header_content].add_next_sibling(
+	    %(<a class="anchor" href="##{entry[:id]}" aria-hidden="true">&nbsp;&#128279;</a>
+	  )
 
-        end
+	  # Add link 'nav to toc'
+	  arrToTop = [ 2, 3 ]
+	  if arrToTop.include?(entry[:h_num]) then
+	    entry[:header_content].add_next_sibling(
+	      %(<span style="float: right"><a href="#toc" aria-hidden="true">&#x21A5;</a></span>)
+	    )
+	  end
+       end
 
         @doc.inner_html
       end

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -25,21 +25,21 @@ module Jekyll
 
       def inject_anchors_into_html
         @entries.each do |entry|
-	  # Add id to h-element
-	  entry[:header_parent].set_attribute("id", "#{entry[:id]}")
+          # Add id to h-element
+          entry[:header_parent].set_attribute("id", "#{entry[:id]}")
 		  
-	  # Add link icon after text
-	  entry[:header_content].add_next_sibling(
-	    %(<a class="anchor" href="##{entry[:id]}" aria-hidden="true">&nbsp;&#128279;</a>
-	  )
+          # Add link icon after text
+          entry[:header_content].add_next_sibling(
+            %(<a class="anchor" href="##{entry[:id]}" aria-hidden="true">&nbsp;&#128279;</a>)
+          )
 
-	  # Add link 'nav to toc'
-	  arrToTop = [ 2, 3 ]
-	  if arrToTop.include?(entry[:h_num]) then
-	    entry[:header_content].add_next_sibling(
-	      %(<span style="float: right"><a href="#toc" aria-hidden="true">&#x21A5;</a></span>)
-	    )
-	  end
+          # Add link 'nav to toc'
+          arrToTop = [ 2, 3 ]
+          if arrToTop.include?(entry[:h_num]) then
+            entry[:header_content].add_next_sibling(
+              %(<span style="float: right"><a href="#toc" aria-hidden="true">&#x21A5;</a></span>)
+            )
+          end
        end
 
         @doc.inner_html

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -28,9 +28,9 @@ module Jekyll
 	  # Add id to h-element
 	  entry[:header_parent].set_attribute("id", "#{entry[:id]}")
 		  
-          entry[:header_content].add_previous_sibling(
-            %(<a class="anchor" href="##{entry[:id]}" aria-hidden="true"><span class="octicon octicon-link"></span></a>)
-          )
+	  # Add link icon after text
+	  entry[:header_content].add_next_sibling(%(<a class="anchor" href="##{entry[:id]}" aria-hidden="true">&nbsp;&#128279;</a>)
+
         end
 
         @doc.inner_html


### PR DESCRIPTION
Url-Encoding for jump-ids, so even non ascii chars can be handled, like the german äöü.
Add css classes to style the elements from outside (css-file).
Navigate back to the top of page /#top or start of TOC /#toc