### PR TITLE
Add Jekyll gem as a runtime_dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,11 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'appraisal'
+gem 'minitest-reporters'
+gem 'minitest'
+gem 'pry'
+gem 'rake'
+gem 'rubocop'
+gem 'simplecov'

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Toshimaru
+Copyright (c) 2020 Toshimaru
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/gemfiles/jekyll_3.7.gemfile
+++ b/gemfiles/jekyll_3.7.gemfile
@@ -2,6 +2,13 @@
 
 source "https://rubygems.org"
 
+gem "appraisal"
+gem "minitest-reporters"
+gem "minitest"
+gem "pry"
+gem "rake"
+gem "rubocop"
+gem "simplecov"
 gem "jekyll", "3.7"
 
 gemspec path: "../"

--- a/gemfiles/jekyll_3.8.gemfile
+++ b/gemfiles/jekyll_3.8.gemfile
@@ -2,6 +2,13 @@
 
 source "https://rubygems.org"
 
+gem "appraisal"
+gem "minitest-reporters"
+gem "minitest"
+gem "pry"
+gem "rake"
+gem "rubocop"
+gem "simplecov"
 gem "jekyll", "3.8"
 
 gemspec path: "../"

--- a/gemfiles/jekyll_4.0.gemfile
+++ b/gemfiles/jekyll_4.0.gemfile
@@ -2,6 +2,13 @@
 
 source "https://rubygems.org"
 
+gem "appraisal"
+gem "minitest-reporters"
+gem "minitest"
+gem "pry"
+gem "rake"
+gem "rubocop"
+gem "simplecov"
 gem "jekyll", "4.0"
 
 gemspec path: "../"

--- a/jekyll-toc.gemspec
+++ b/jekyll-toc.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.name          = 'jekyll-toc'
   spec.version       = JekyllToc::VERSION
   spec.summary       = 'Jekyll Table of Contents plugin'
-  spec.description   = 'A liquid filter plugin for Jekyll which generates a table of contents.'
+  spec.description   = 'Jekyll (Ruby static website generator) plugin which generates a table of contents.'
   spec.authors       = %w(toshimaru torbjoernk)
   spec.email         = 'me@toshimaru.net'
   spec.files         = `git ls-files -z`.split("\x0")

--- a/jekyll-toc.gemspec
+++ b/jekyll-toc.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'version'
@@ -17,11 +19,11 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.4'
 
+  spec.add_runtime_dependency 'jekyll', '>= 3.7'
   spec.add_runtime_dependency 'nokogiri', '~> 1.9'
 
   spec.add_development_dependency 'appraisal'
-  spec.add_development_dependency 'jekyll', '>= 3.7'
-  spec.add_development_dependency 'minitest', '~> 5.11'
+  spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'minitest-reporters'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'

--- a/jekyll-toc.gemspec
+++ b/jekyll-toc.gemspec
@@ -19,14 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.4'
 
-  spec.add_runtime_dependency 'jekyll', '>= 3.7'
-  spec.add_runtime_dependency 'nokogiri', '~> 1.9'
-
-  spec.add_development_dependency 'appraisal'
-  spec.add_development_dependency 'minitest'
-  spec.add_development_dependency 'minitest-reporters'
-  spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rubocop'
-  spec.add_development_dependency 'simplecov'
+  spec.add_dependency 'jekyll', '>= 3.7'
+  spec.add_dependency 'nokogiri', '~> 1.9'
 end


### PR DESCRIPTION
- Year update: 2019 -> 2020
- Add jekyll as jekyll-toc runtime dependency