### PR TITLE
Url Encoding for Anchor IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ toc:
   sublist_class: ''
   item_class: toc-entry
   item_prefix: toc-
+  anchor_id_url_encoded: false
 ```
 
 ## Customization

--- a/lib/table_of_contents/configuration.rb
+++ b/lib/table_of_contents/configuration.rb
@@ -5,7 +5,8 @@ module Jekyll
     # jekyll-toc configuration class
     class Configuration
       attr_accessor :toc_levels, :no_toc_class, :no_toc_section_class,
-                    :list_class, :sublist_class, :item_class, :item_prefix
+                    :list_class, :sublist_class, :item_class, :item_prefix,
+                    :anchor_id_url_encoded
 
       DEFAULT_CONFIG = {
         'min_level' => 1,
@@ -14,7 +15,8 @@ module Jekyll
         'list_class' => 'section-nav',
         'sublist_class' => '',
         'item_class' => 'toc-entry',
-        'item_prefix' => 'toc-'
+        'item_prefix' => 'toc-',
+        'anchor_id_url_encoded' => false
       }.freeze
 
       def initialize(options)
@@ -27,6 +29,7 @@ module Jekyll
         @sublist_class = options['sublist_class']
         @item_class = options['item_class']
         @item_prefix = options['item_prefix']
+        @anchor_id_url_encoded = options['anchor_id_url_encoded']
       end
 
       private

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -48,7 +48,9 @@ module Jekyll
                .downcase
                .gsub(PUNCTUATION_REGEXP, '') # remove punctuation
                .tr(' ', '-') # replace spaces with dash
-          id = url_encode(id)
+          if (@configuration.anchor_id_url_encoded)
+            id = url_encode(id)
+          end
 
           suffix_num = headers[id]
           headers[id] += 1

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "erb"
+include ERB::Util
+
 module Jekyll
   module TableOfContents
     # Parse html contents and generate table of contents
@@ -45,6 +48,7 @@ module Jekyll
                .downcase
                .gsub(PUNCTUATION_REGEXP, '') # remove punctuation
                .tr(' ', '-') # replace spaces with dash
+          id = url_encode(id)
 
           suffix_num = headers[id]
           headers[id] += 1

--- a/test/parser/test_toc_only_filter_encoding.rb
+++ b/test/parser/test_toc_only_filter_encoding.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'test_helper_encoding'
+
+class TestTOCOnlyFilterEncodingOn < Minitest::Test
+  include TestHelpersEncoding
+
+  def setup
+    read_html_and_create_parser(true)
+  end
+
+  def test_injects_toc_container_with_anchor_id_url_encoded
+    html = @parser.build_toc
+
+    assert_match(/<ul class="section-nav">/, html)
+
+    assert_match(/<a href="#123">/, html)
+    assert_match(/<a href="#simple-h2a">/, html)
+    assert_match(/<a href="#simple-h2b">/, html)
+    assert_match(/<a href="#sub-h3">/, html)
+    assert_match(/<a href="#simple-h3b">/, html)
+    assert_match(/<a href="#simple-h3c-%C3%BC%C3%A4%C3%B6">/, html)
+  end
+
+  def test_does_not_return_content
+    html = @parser.build_toc
+
+    assert_nil(%r{<h1 id="123">Simple H1</h1>} =~ html)
+  end
+
+  class TestTOCOnlyFilterEncodingOff < Minitest::Test
+    include TestHelpersEncoding
+    
+    def setup
+      read_html_and_create_parser(false)
+    end
+
+    def test_injects_toc_container_without_anchor_id_url_encoded
+      html = @parser.build_toc
+  
+      assert_match(/<ul class="section-nav">/, html)
+  
+      assert_match(/<a href="#123">/, html)
+      assert_match(/<a href="#simple-h2a">/, html)
+      assert_match(/<a href="#simple-h2b">/, html)
+      assert_match(/<a href="#sub-h3">/, html)
+      assert_match(/<a href="#simple-h3b">/, html)
+      assert_match(/<a href="#simple-h3c-üäö">/, html)
+    end
+  end
+end

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -12,6 +12,7 @@ class TestConfiguration < Minitest::Test
     assert_equal configuration.sublist_class, ''
     assert_equal configuration.item_class, 'toc-entry'
     assert_equal configuration.item_prefix, 'toc-'
+    assert_equal configuration.anchor_id_url_encoded, false
   end
 
   def test_type_error
@@ -23,5 +24,6 @@ class TestConfiguration < Minitest::Test
     assert_equal configuration.sublist_class, ''
     assert_equal configuration.item_class, 'toc-entry'
     assert_equal configuration.item_prefix, 'toc-'
+    assert_equal configuration.anchor_id_url_encoded, false
   end
 end

--- a/test/test_helper_encoding.rb
+++ b/test/test_helper_encoding.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'simplecov'
+SimpleCov.start
+
+require 'minitest/autorun'
+require 'minitest/reporters'
+Minitest::Reporters.use!
+
+require 'jekyll'
+require 'jekyll-toc'
+require 'table_of_contents/configuration'
+
+SIMPLE_HTML_WITH_IDS = <<~HTML
+  <h1 id="123">Simple H1</h1>
+  <h2>Simple H2a</h2>
+  <h2>Simple H2b</h2>
+  <h3 id="sub-h3">Simple H3a</h3>
+  <h3>Simple H3b</h3>
+  <h3>Simple H3c ÜÄÖ</h3>
+HTML
+
+module TestHelpersEncoding
+  def read_html_and_create_parser(anchor_id_url_encoded)
+    @parser = Jekyll::TableOfContents::Parser.new(SIMPLE_HTML_WITH_IDS)
+    @config = Jekyll::TableOfContents::Configuration.new({})
+    @config.anchor_id_url_encoded = anchor_id_url_encoded
+  end
+end


### PR DESCRIPTION
Add new config value
Use the config value inside the parser
Create Unit Tests

https://github.com/toshimaru/jekyll-toc/issues/95