### PR TITLE
URL-Encoding for anchor link inside toc

### DIFF
--- a/lib/table_of_contents/configuration.rb
+++ b/lib/table_of_contents/configuration.rb
@@ -4,8 +4,8 @@ module Jekyll
   module TableOfContents
     # jekyll-toc configuration class
     class Configuration
-      attr_accessor :toc_levels, :no_toc_class, :no_toc_section_class,
-                    :list_class, :sublist_class, :item_class, :item_prefix
+      attr_reader :toc_levels, :no_toc_class, :no_toc_section_class,
+                  :list_class, :sublist_class, :item_class, :item_prefix
 
       DEFAULT_CONFIG = {
         'min_level' => 1,

--- a/lib/table_of_contents/helper.rb
+++ b/lib/table_of_contents/helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module TableOfContents
+    # helper methods for Parser
+    module Helper
+      PUNCTUATION_REGEXP = /[^\p{Word}\- ]/u.freeze
+
+      def generate_toc_id(text)
+        text.downcase
+            .gsub(PUNCTUATION_REGEXP, '') # remove punctuation
+            .tr(' ', '-') # replace spaces with dash
+      end
+    end
+  end
+end

--- a/lib/table_of_contents/helper.rb
+++ b/lib/table_of_contents/helper.rb
@@ -7,9 +7,10 @@ module Jekyll
       PUNCTUATION_REGEXP = /[^\p{Word}\- ]/u.freeze
 
       def generate_toc_id(text)
-        text.downcase
-            .gsub(PUNCTUATION_REGEXP, '') # remove punctuation
-            .tr(' ', '-') # replace spaces with dash
+        text = text.downcase
+                   .gsub(PUNCTUATION_REGEXP, '') # remove punctuation
+                   .tr(' ', '-') # replace spaces with dash
+        CGI.escape(text)
       end
     end
   end

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -6,8 +6,7 @@ module Jekyll
   module TableOfContents
     # Parse html contents and generate table of contents
     class Parser
-      include ERB::Util
-      include Helper
+      include ::Jekyll::TableOfContents::Helper
 
       def initialize(html, options = {})
         @doc = Nokogiri::HTML::DocumentFragment.parse(html)
@@ -45,7 +44,6 @@ module Jekyll
           .inject([]) do |entries, node|
           text = node.text
           id = node.attribute('id') || generate_toc_id(text)
-          id = url_encode(id)
 
           suffix_num = headers[id]
           headers[id] += 1

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "erb"
+include ERB::Util
+
 module Jekyll
   module TableOfContents
     # Parse html contents and generate table of contents
@@ -45,6 +48,7 @@ module Jekyll
                .downcase
                .gsub(PUNCTUATION_REGEXP, '') # remove punctuation
                .tr(' ', '-') # replace spaces with dash
+          id = url_encode(id)
 
           suffix_num = headers[id]
           headers[id] += 1

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -24,6 +24,7 @@ module Jekyll
 
       def inject_anchors_into_html
         @entries.each do |entry|
+          # NOTE: `entry[:id]` is automatically URL encoded by Nokogiri
           entry[:header_content].add_previous_sibling(
             %(<a class="anchor" href="##{entry[:id]}" aria-hidden="true"><span class="octicon octicon-link"></span></a>)
           )

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require "erb"
-include ERB::Util
+require 'table_of_contents/helper'
 
 module Jekyll
   module TableOfContents
     # Parse html contents and generate table of contents
     class Parser
-      PUNCTUATION_REGEXP = /[^\p{Word}\- ]/u.freeze
+      include ERB::Util
+      include Helper
 
       def initialize(html, options = {})
         @doc = Nokogiri::HTML::DocumentFragment.parse(html)
@@ -44,10 +44,7 @@ module Jekyll
           .reject { |n| n.classes.include?(@configuration.no_toc_class) }
           .inject([]) do |entries, node|
           text = node.text
-          id = node.attribute('id') || text
-               .downcase
-               .gsub(PUNCTUATION_REGEXP, '') # remove punctuation
-               .tr(' ', '-') # replace spaces with dash
+          id = node.attribute('id') || generate_toc_id(text)
           id = url_encode(id)
 
           suffix_num = headers[id]

--- a/test/parser/test_invalid_options.rb
+++ b/test/parser/test_invalid_options.rb
@@ -2,9 +2,9 @@
 
 require 'test_helper'
 
-class TestOptionError < Minitest::Test
+class TestInvalidOptions < Minitest::Test
   BASE_HTML = '<h1>h1</h1>'
-  EXPECTED_HTML = <<~HTML
+  EXPECTED_HTML = <<~HTML.chomp
     <ul class="section-nav">
     <li class="toc-entry toc-h1"><a href="#h1">h1</a></li>
     </ul>
@@ -12,29 +12,21 @@ class TestOptionError < Minitest::Test
 
   def test_option_is_nil
     parser = Jekyll::TableOfContents::Parser.new(BASE_HTML, nil)
-    doc = Nokogiri::HTML(parser.toc)
-    expected = EXPECTED_HTML
-    assert_equal(expected, doc.css('ul.section-nav').to_s)
+    assert_equal(EXPECTED_HTML, parser.build_toc)
   end
 
   def test_option_is_epmty_string
     parser = Jekyll::TableOfContents::Parser.new(BASE_HTML, '')
-    doc = Nokogiri::HTML(parser.toc)
-    expected = EXPECTED_HTML
-    assert_equal(expected, doc.css('ul.section-nav').to_s)
+    assert_equal(EXPECTED_HTML, parser.build_toc)
   end
 
   def test_option_is_string
     parser = Jekyll::TableOfContents::Parser.new(BASE_HTML, 'string')
-    doc = Nokogiri::HTML(parser.toc)
-    expected = EXPECTED_HTML
-    assert_equal(expected, doc.css('ul.section-nav').to_s)
+    assert_equal(EXPECTED_HTML, parser.build_toc)
   end
 
   def test_option_is_array
     parser = Jekyll::TableOfContents::Parser.new(BASE_HTML, [])
-    doc = Nokogiri::HTML(parser.toc)
-    expected = EXPECTED_HTML
-    assert_equal(expected, doc.css('ul.section-nav').to_s)
+    assert_equal(EXPECTED_HTML, parser.build_toc)
   end
 end

--- a/test/parser/test_various_toc_html.rb
+++ b/test/parser/test_various_toc_html.rb
@@ -21,12 +21,6 @@ class TestVariousTocHtml < Minitest::Test
     <h4 class="no_toc">no_toc h4</h4>
   HTML
 
-  JAPANESE_HEADINGS_HTML = <<~HTML
-    <h1>あ</h1>
-    <h2>い</h2>
-    <h3>う</h3>
-  HTML
-
   TAGS_INSIDE_HEADINGS_HTML = <<~HTML
     <h2><strong>h2</strong></h2>
     <h2><em>h2</em></h2>
@@ -197,26 +191,26 @@ class TestVariousTocHtml < Minitest::Test
   end
 
   def test_japanese_toc
-    parser = Jekyll::TableOfContents::Parser.new(JAPANESE_HEADINGS_HTML)
-    doc = Nokogiri::HTML(parser.toc)
-    expected = <<~HTML
+    parser = Jekyll::TableOfContents::Parser.new(<<~HTML)
+      <h1>あ</h1>
+      <h2>い</h2>
+      <h3>う</h3>
+    HTML
+    expected = <<~HTML.chomp
       <ul class="section-nav">
-      <li class="toc-entry toc-h1">
-      <a href="#%E3%81%82">あ</a>
+      <li class="toc-entry toc-h1"><a href="#あ">あ</a>
       <ul>
-      <li class="toc-entry toc-h2">
-      <a href="#%E3%81%84">い</a>
+      <li class="toc-entry toc-h2"><a href="#い">い</a>
       <ul>
-      <li class="toc-entry toc-h3"><a href="#%E3%81%86">う</a></li>
+      <li class="toc-entry toc-h3"><a href="#う">う</a></li>
       </ul>
       </li>
       </ul>
       </li>
       </ul>
     HTML
-    actual = doc.css('ul.section-nav').to_s
 
-    assert_equal(expected, actual)
+    assert_equal(expected, parser.build_toc)
   end
 
   def test_angle_bracket

--- a/test/parser/test_various_toc_html.rb
+++ b/test/parser/test_various_toc_html.rb
@@ -170,6 +170,10 @@ class TestVariousTocHtml < Minitest::Test
     HTML
 
     assert_equal(expected, parser.build_toc)
+    html_with_anchors = parser.inject_anchors_into_html
+    assert_match(%r{<a class="anchor" href="#%E3%81%82" aria-hidden="true"><span.*span></a>あ}, html_with_anchors)
+    assert_match(%r{<a class="anchor" href="#%E3%81%84" aria-hidden="true"><span.*span></a>い}, html_with_anchors)
+    assert_match(%r{<a class="anchor" href="#%E3%81%86" aria-hidden="true"><span.*span></a>う}, html_with_anchors)
   end
 
   # ref. https://github.com/toshimaru/jekyll-toc/issues/45

--- a/test/parser/test_various_toc_html.rb
+++ b/test/parser/test_various_toc_html.rb
@@ -157,11 +157,11 @@ class TestVariousTocHtml < Minitest::Test
     HTML
     expected = <<~HTML.chomp
       <ul class="section-nav">
-      <li class="toc-entry toc-h1"><a href="#あ">あ</a>
+      <li class="toc-entry toc-h1"><a href="#%E3%81%82">あ</a>
       <ul>
-      <li class="toc-entry toc-h2"><a href="#い">い</a>
+      <li class="toc-entry toc-h2"><a href="#%E3%81%84">い</a>
       <ul>
-      <li class="toc-entry toc-h3"><a href="#う">う</a></li>
+      <li class="toc-entry toc-h3"><a href="#%E3%81%86">う</a></li>
       </ul>
       </li>
       </ul>

--- a/test/parser/test_various_toc_html.rb
+++ b/test/parser/test_various_toc_html.rb
@@ -3,69 +3,19 @@
 require 'test_helper'
 
 class TestVariousTocHtml < Minitest::Test
-  # ref. https://github.com/toshimaru/jekyll-toc/issues/45
-  ANGLE_BRACKET_HTML = <<~HTML
-    <h1>h1</h1>
-    <h1>&lt;base href&gt;</h1>
-    <h1>&amp; &lt; &gt;</h1>
-  HTML
-
-  NO_TOC_HTML = <<~HTML
-    <h1>h1</h1>
-    <h1 class="no_toc">no_toc h1</h1>
-    <h2>h2</h2>
-    <h2 class="no_toc">no_toc h2</h2>
-    <h3>h3</h3>
-    <h3 class="no_toc">no_toc h3</h3>
-    <h4>h4</h4>
-    <h4 class="no_toc">no_toc h4</h4>
-  HTML
-
-  TAGS_INSIDE_HEADINGS_HTML = <<~HTML
-    <h2><strong>h2</strong></h2>
-    <h2><em>h2</em></h2>
-  HTML
-
-  TEST_HTML_1 = <<~HTML
+  TEST_HTML = <<~HTML
     <h1>h1</h1>
     <h3>h3</h3>
     <h6>h6</h6>
-  HTML
-
-  TEST_HTML_2 = <<~HTML
-    <h1>h1</h1>
-    <h3>h3</h3>
-    <h2>h2</h2>
-    <h6>h6</h6>
-  HTML
-
-  TEST_HTML_3 = <<~HTML
-    <h6>h6</h6>
-    <h5>h5</h5>
-    <h4>h4</h4>
-    <h3>h3</h3>
-    <h2>h2</h2>
-    <h1>h1</h1>
-  HTML
-
-  TEST_HTML_4 = <<~HTML
-    <h1>h1</h1>
-    <h3>h3</h3>
-    <h2>h2</h2>
-    <h4>h4</h4>
-    <h5>h5</h5>
   HTML
 
   def test_nested_toc
-    parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_1)
-    doc = Nokogiri::HTML(parser.toc)
-    expected = <<~HTML
+    parser = Jekyll::TableOfContents::Parser.new(TEST_HTML)
+    expected = <<~HTML.chomp
       <ul class="section-nav">
-      <li class="toc-entry toc-h1">
-      <a href="#h1">h1</a>
+      <li class="toc-entry toc-h1"><a href="#h1">h1</a>
       <ul>
-      <li class="toc-entry toc-h3">
-      <a href="#h3">h3</a>
+      <li class="toc-entry toc-h3"><a href="#h3">h3</a>
       <ul>
       <li class="toc-entry toc-h6"><a href="#h6">h6</a></li>
       </ul>
@@ -74,35 +24,34 @@ class TestVariousTocHtml < Minitest::Test
       </li>
       </ul>
     HTML
-    actual = doc.css('ul.section-nav').to_s
 
-    assert_equal(expected, actual)
+    assert_equal(expected, parser.build_toc)
   end
 
   def test_nested_toc_with_min_and_max
-    parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_1, 'min_level' => 2, 'max_level' => 5)
-    doc = Nokogiri::HTML(parser.toc)
-    expected = <<~HTML
+    parser = Jekyll::TableOfContents::Parser.new(TEST_HTML, 'min_level' => 2, 'max_level' => 5)
+    expected = <<~HTML.chomp
       <ul class="section-nav">
       <li class="toc-entry toc-h3"><a href="#h3">h3</a></li>
       </ul>
     HTML
-    actual = doc.css('ul.section-nav').to_s
 
-    assert_equal(expected, actual)
+    assert_equal(expected, parser.build_toc)
   end
 
   def test_complex_nested_toc
-    parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_2)
-    doc = Nokogiri::HTML(parser.toc)
-    expected = <<~HTML
+    parser = Jekyll::TableOfContents::Parser.new(<<~HTML)
+      <h1>h1</h1>
+      <h3>h3</h3>
+      <h2>h2</h2>
+      <h6>h6</h6>
+    HTML
+    expected = <<~HTML.chomp
       <ul class="section-nav">
-      <li class="toc-entry toc-h1">
-      <a href="#h1">h1</a>
+      <li class="toc-entry toc-h1"><a href="#h1">h1</a>
       <ul>
       <li class="toc-entry toc-h3"><a href="#h3">h3</a></li>
-      <li class="toc-entry toc-h2">
-      <a href="#h2">h2</a>
+      <li class="toc-entry toc-h2"><a href="#h2">h2</a>
       <ul>
       <li class="toc-entry toc-h6"><a href="#h6">h6</a></li>
       </ul>
@@ -111,15 +60,20 @@ class TestVariousTocHtml < Minitest::Test
       </li>
       </ul>
     HTML
-    actual = doc.css('ul.section-nav').to_s
 
-    assert_equal(expected, actual)
+    assert_equal(expected, parser.build_toc)
   end
 
   def test_decremental_headings1
-    parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_3)
-    doc = Nokogiri::HTML(parser.toc)
-    expected = <<~HTML
+    parser = Jekyll::TableOfContents::Parser.new(<<~HTML)
+      <h6>h6</h6>
+      <h5>h5</h5>
+      <h4>h4</h4>
+      <h3>h3</h3>
+      <h2>h2</h2>
+      <h1>h1</h1>
+    HTML
+    expected = <<~HTML.chomp
       <ul class="section-nav">
       <li class="toc-entry toc-h6"><a href="#h6">h6</a></li>
       <li class="toc-entry toc-h5"><a href="#h5">h5</a></li>
@@ -129,25 +83,26 @@ class TestVariousTocHtml < Minitest::Test
       <li class="toc-entry toc-h1"><a href="#h1">h1</a></li>
       </ul>
     HTML
-    actual = doc.css('ul.section-nav').to_s
 
-    assert_equal(expected, actual)
+    assert_equal(expected, parser.build_toc)
   end
 
   def test_decremental_headings2
-    parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_4)
-    doc = Nokogiri::HTML(parser.toc)
-    expected = <<~HTML
+    parser = Jekyll::TableOfContents::Parser.new(<<~HTML)
+      <h1>h1</h1>
+      <h3>h3</h3>
+      <h2>h2</h2>
+      <h4>h4</h4>
+      <h5>h5</h5>
+    HTML
+    expected = <<~HTML.chomp
       <ul class="section-nav">
-      <li class="toc-entry toc-h1">
-      <a href="#h1">h1</a>
+      <li class="toc-entry toc-h1"><a href="#h1">h1</a>
       <ul>
       <li class="toc-entry toc-h3"><a href="#h3">h3</a></li>
-      <li class="toc-entry toc-h2">
-      <a href="#h2">h2</a>
+      <li class="toc-entry toc-h2"><a href="#h2">h2</a>
       <ul>
-      <li class="toc-entry toc-h4">
-      <a href="#h4">h4</a>
+      <li class="toc-entry toc-h4"><a href="#h4">h4</a>
       <ul>
       <li class="toc-entry toc-h5"><a href="#h5">h5</a></li>
       </ul>
@@ -159,22 +114,27 @@ class TestVariousTocHtml < Minitest::Test
       </ul>
     HTML
 
-    assert_equal(expected, doc.css('ul.section-nav').to_s)
+    assert_equal(expected, parser.build_toc)
   end
 
   def test_no_toc
-    parser = Jekyll::TableOfContents::Parser.new(NO_TOC_HTML)
-    doc = Nokogiri::HTML(parser.toc)
-    expected = <<~HTML
+    parser = Jekyll::TableOfContents::Parser.new(<<~HTML)
+      <h1>h1</h1>
+      <h1 class="no_toc">no_toc h1</h1>
+      <h2>h2</h2>
+      <h2 class="no_toc">no_toc h2</h2>
+      <h3>h3</h3>
+      <h3 class="no_toc">no_toc h3</h3>
+      <h4>h4</h4>
+      <h4 class="no_toc">no_toc h4</h4>
+    HTML
+    expected = <<~HTML.chomp
       <ul class="section-nav">
-      <li class="toc-entry toc-h1">
-      <a href="#h1">h1</a>
+      <li class="toc-entry toc-h1"><a href="#h1">h1</a>
       <ul>
-      <li class="toc-entry toc-h2">
-      <a href="#h2">h2</a>
+      <li class="toc-entry toc-h2"><a href="#h2">h2</a>
       <ul>
-      <li class="toc-entry toc-h3">
-      <a href="#h3">h3</a>
+      <li class="toc-entry toc-h3"><a href="#h3">h3</a>
       <ul>
       <li class="toc-entry toc-h4"><a href="#h4">h4</a></li>
       </ul>
@@ -185,9 +145,8 @@ class TestVariousTocHtml < Minitest::Test
       </li>
       </ul>
     HTML
-    actual = doc.css('ul.section-nav').to_s
 
-    assert_equal(expected, actual)
+    assert_equal(expected, parser.build_toc)
   end
 
   def test_japanese_toc
@@ -213,33 +172,37 @@ class TestVariousTocHtml < Minitest::Test
     assert_equal(expected, parser.build_toc)
   end
 
+  # ref. https://github.com/toshimaru/jekyll-toc/issues/45
   def test_angle_bracket
-    parser = Jekyll::TableOfContents::Parser.new(ANGLE_BRACKET_HTML)
-    doc = Nokogiri::HTML(parser.toc)
-    expected = <<~HTML
+    parser = Jekyll::TableOfContents::Parser.new(<<~HTML)
+      <h1>h1</h1>
+      <h1>&lt;base href&gt;</h1>
+      <h1>&amp; &lt; &gt;</h1>
+    HTML
+    expected = <<~HTML.chomp
       <ul class="section-nav">
       <li class="toc-entry toc-h1"><a href="#h1">h1</a></li>
       <li class="toc-entry toc-h1"><a href="#base-href">&lt;base href&gt;</a></li>
       <li class="toc-entry toc-h1"><a href="#--">&amp; &lt; &gt;</a></li>
       </ul>
     HTML
-    actual = doc.css('ul.section-nav').to_s
 
-    assert_equal(expected, actual)
+    assert_equal(expected, parser.build_toc)
   end
 
   def test_tags_inside_heading
-    parser = Jekyll::TableOfContents::Parser.new(TAGS_INSIDE_HEADINGS_HTML)
-    doc = Nokogiri::HTML(parser.toc)
-    expected = <<~HTML
+    parser = Jekyll::TableOfContents::Parser.new(<<~HTML)
+      <h2><strong>h2</strong></h2>
+      <h2><em>h2</em></h2>
+    HTML
+    expected = <<~HTML.chomp
       <ul class="section-nav">
       <li class="toc-entry toc-h2"><a href="#h2">h2</a></li>
       <li class="toc-entry toc-h2"><a href="#h2-1">h2</a></li>
       </ul>
     HTML
-    actual = doc.css('ul.section-nav').to_s
 
-    assert_equal(expected, actual)
+    assert_equal(expected, parser.build_toc)
   end
 
   TEST_HTML_IGNORE = <<~HTML
@@ -279,29 +242,24 @@ class TestVariousTocHtml < Minitest::Test
     assert_includes(html, '<h2>h2</h2>')
   end
 
-  TEST_HTML_IGNORE_2 = <<~HTML
-    <h1>h1</h1>
-    <div class="exclude">
-    <h2>h2</h2>
-    </div>
-    <h3>h3</h3>
-    <div class="exclude">
-    <h4>h4</h4>
-    <h5>h5</h5>
-    </div>
-    <h6>h6</h6>
-  HTML
-
   def test_nested_toc_with_no_toc_section_class_option
-    parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_IGNORE_2, 'no_toc_section_class' => 'exclude')
-    doc = Nokogiri::HTML(parser.toc)
-    expected = <<~HTML
+    parser = Jekyll::TableOfContents::Parser.new(<<~HTML, 'no_toc_section_class' => 'exclude')
+      <h1>h1</h1>
+      <div class="exclude">
+      <h2>h2</h2>
+      </div>
+      <h3>h3</h3>
+      <div class="exclude">
+      <h4>h4</h4>
+      <h5>h5</h5>
+      </div>
+      <h6>h6</h6>
+    HTML
+    expected = <<~HTML.chomp
       <ul class="section-nav">
-      <li class="toc-entry toc-h1">
-      <a href="#h1">h1</a>
+      <li class="toc-entry toc-h1"><a href="#h1">h1</a>
       <ul>
-      <li class="toc-entry toc-h3">
-      <a href="#h3">h3</a>
+      <li class="toc-entry toc-h3"><a href="#h3">h3</a>
       <ul>
       <li class="toc-entry toc-h6"><a href="#h6">h6</a></li>
       </ul>
@@ -310,8 +268,7 @@ class TestVariousTocHtml < Minitest::Test
       </li>
       </ul>
     HTML
-    actual = doc.css('ul.section-nav').to_s
-    assert_equal(expected, actual)
+    assert_equal(expected, parser.build_toc)
 
     html = parser.inject_anchors_into_html
     assert_match(%r{<h1>.+</h1>}m, html)
@@ -390,29 +347,25 @@ class TestVariousTocHtml < Minitest::Test
     assert_includes(html, %(<a class="anchor" href="#third" aria-hidden="true">))
   end
 
-  TEST_UNIQ_ID = <<~HTML
-    <h1>h1</h1>
-    <h1>h1</h1>
-    <h1>h1</h1>
-  HTML
-
   def test_anchor_is_uniq
-    parser = Jekyll::TableOfContents::Parser.new(TEST_UNIQ_ID)
-    doc = Nokogiri::HTML(parser.toc)
-    expected = <<~HTML
+    parser = Jekyll::TableOfContents::Parser.new(<<~HTML)
+      <h1>h1</h1>
+      <h1>h1</h1>
+      <h1>h1</h1>
+    HTML
+    expected = <<~HTML.chomp
       <ul class="section-nav">
       <li class="toc-entry toc-h1"><a href="#h1">h1</a></li>
       <li class="toc-entry toc-h1"><a href="#h1-1">h1</a></li>
       <li class="toc-entry toc-h1"><a href="#h1-2">h1</a></li>
       </ul>
     HTML
-    actual = doc.css('ul.section-nav').to_s
-    assert_equal(expected, actual)
+    assert_equal(expected, parser.build_toc)
   end
 
   def test_custom_css_classes
     parser = Jekyll::TableOfContents::Parser.new(
-      TEST_HTML_1,
+      TEST_HTML,
       'item_class' => 'custom-item', 'list_class' => 'custom-list', 'sublist_class' => 'custom-sublist', 'item_prefix' => 'custom-prefix-'
     )
     doc = Nokogiri::HTML(parser.toc)

--- a/test/parser/test_various_toc_html.rb
+++ b/test/parser/test_various_toc_html.rb
@@ -205,25 +205,20 @@ class TestVariousTocHtml < Minitest::Test
     assert_equal(expected, parser.build_toc)
   end
 
-  TEST_HTML_IGNORE = <<~HTML
-    <h1>h1</h1>
-    <div class="no_toc_section">
-    <h2>h2</h2>
-    </div>
-    <h3>h3</h3>
-    <h6>h6</h6>
-  HTML
-
   def test_nested_toc_with_no_toc_section_class
-    parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_IGNORE)
-    doc = Nokogiri::HTML(parser.toc)
-    expected = <<~HTML
+    parser = Jekyll::TableOfContents::Parser.new(<<~HTML)
+      <h1>h1</h1>
+      <div class="no_toc_section">
+      <h2>h2</h2>
+      </div>
+      <h3>h3</h3>
+      <h6>h6</h6>
+    HTML
+    expected = <<~HTML.chomp
       <ul class="section-nav">
-      <li class="toc-entry toc-h1">
-      <a href="#h1">h1</a>
+      <li class="toc-entry toc-h1"><a href="#h1">h1</a>
       <ul>
-      <li class="toc-entry toc-h3">
-      <a href="#h3">h3</a>
+      <li class="toc-entry toc-h3"><a href="#h3">h3</a>
       <ul>
       <li class="toc-entry toc-h6"><a href="#h6">h6</a></li>
       </ul>
@@ -232,8 +227,7 @@ class TestVariousTocHtml < Minitest::Test
       </li>
       </ul>
     HTML
-    actual = doc.css('ul.section-nav').to_s
-    assert_equal(expected, actual)
+    assert_equal(expected, parser.build_toc)
 
     html = parser.inject_anchors_into_html
     assert_match(%r{<h1>.+</h1>}m, html)
@@ -279,29 +273,24 @@ class TestVariousTocHtml < Minitest::Test
     assert_includes(html, '<h5>h5</h5>')
   end
 
-  TEST_HTML_IGNORE_3 = <<~HTML
-    <h1>h1</h1>
-    <div class="no_toc_section">
-    <h2>h2</h2>
-    </div>
-    <h3>h3</h3>
-    <div class="exclude">
-    <h4>h4</h4>
-    <h5>h5</h5>
-    </div>
-    <h6>h6</h6>
-  HTML
-
   def test_multiple_no_toc_section_classes
-    parser = Jekyll::TableOfContents::Parser.new(TEST_HTML_IGNORE_3, 'no_toc_section_class' => ['no_toc_section', 'exclude'])
-    doc = Nokogiri::HTML(parser.toc)
-    expected = <<~HTML
+    parser = Jekyll::TableOfContents::Parser.new(<<~HTML, 'no_toc_section_class' => ['no_toc_section', 'exclude'])
+      <h1>h1</h1>
+      <div class="no_toc_section">
+      <h2>h2</h2>
+      </div>
+      <h3>h3</h3>
+      <div class="exclude">
+      <h4>h4</h4>
+      <h5>h5</h5>
+      </div>
+      <h6>h6</h6>
+    HTML
+    expected = <<~HTML.chomp
       <ul class="section-nav">
-      <li class="toc-entry toc-h1">
-      <a href="#h1">h1</a>
+      <li class="toc-entry toc-h1"><a href="#h1">h1</a>
       <ul>
-      <li class="toc-entry toc-h3">
-      <a href="#h3">h3</a>
+      <li class="toc-entry toc-h3"><a href="#h3">h3</a>
       <ul>
       <li class="toc-entry toc-h6"><a href="#h6">h6</a></li>
       </ul>
@@ -310,8 +299,7 @@ class TestVariousTocHtml < Minitest::Test
       </li>
       </ul>
     HTML
-    actual = doc.css('ul.section-nav').to_s
-    assert_equal(expected, actual)
+    assert_equal(expected, parser.build_toc)
 
     html = parser.inject_anchors_into_html
     assert_match(%r{<h1>.+</h1>}m, html)
@@ -322,24 +310,20 @@ class TestVariousTocHtml < Minitest::Test
     assert_includes(html, '<h5>h5</h5>')
   end
 
-  TEST_EXPLICIT_ID = <<~HTML
-    <h1>h1</h1>
-    <h1 id="second">h2</h1>
-    <h1 id="third">h3</h1>
-  HTML
-
   def test_toc_with_explicit_id
-    parser = Jekyll::TableOfContents::Parser.new(TEST_EXPLICIT_ID)
-    doc = Nokogiri::HTML(parser.toc)
-    expected = <<~HTML
+    parser = Jekyll::TableOfContents::Parser.new(<<~HTML)
+      <h1>h1</h1>
+      <h1 id="second">h2</h1>
+      <h1 id="third">h3</h1>
+    HTML
+    expected = <<~HTML.chomp
       <ul class="section-nav">
       <li class="toc-entry toc-h1"><a href="#h1">h1</a></li>
       <li class="toc-entry toc-h1"><a href="#second">h2</a></li>
       <li class="toc-entry toc-h1"><a href="#third">h3</a></li>
       </ul>
     HTML
-    actual = doc.css('ul.section-nav').to_s
-    assert_equal(expected, actual)
+    assert_equal(expected, parser.build_toc)
 
     html = parser.inject_anchors_into_html
     assert_includes(html, %(<a class="anchor" href="#h1" aria-hidden="true">))
@@ -360,6 +344,7 @@ class TestVariousTocHtml < Minitest::Test
       <li class="toc-entry toc-h1"><a href="#h1-2">h1</a></li>
       </ul>
     HTML
+
     assert_equal(expected, parser.build_toc)
   end
 
@@ -368,14 +353,11 @@ class TestVariousTocHtml < Minitest::Test
       TEST_HTML,
       'item_class' => 'custom-item', 'list_class' => 'custom-list', 'sublist_class' => 'custom-sublist', 'item_prefix' => 'custom-prefix-'
     )
-    doc = Nokogiri::HTML(parser.toc)
-    expected = <<~HTML
+    expected = <<~HTML.chomp
       <ul class="custom-list">
-      <li class="custom-item custom-prefix-h1">
-      <a href="#h1">h1</a>
+      <li class="custom-item custom-prefix-h1"><a href="#h1">h1</a>
       <ul class="custom-sublist">
-      <li class="custom-item custom-prefix-h3">
-      <a href="#h3">h3</a>
+      <li class="custom-item custom-prefix-h3"><a href="#h3">h3</a>
       <ul class="custom-sublist">
       <li class="custom-item custom-prefix-h6"><a href="#h6">h6</a></li>
       </ul>
@@ -385,6 +367,6 @@ class TestVariousTocHtml < Minitest::Test
       </ul>
     HTML
 
-    assert_equal(expected, doc.css('ul.custom-list').to_s)
+    assert_equal(expected, parser.build_toc)
   end
 end


### PR DESCRIPTION
closes #95, closes  #101

## Description

<details>
 <summary>BEFORE</summary>

href inside toc:

```html
<li class="toc-entry toc-h1"><a href="#あ">あ</a>
```

href inside the anchor:

```html
<a class="anchor" href="#%E3%81%82" aria-hidden="true"> ...あ
```
</details>

<details>
 <summary>AFTER</summary>

href inside toc:

```html
<li class="toc-entry toc-h1"><a href="#%E3%81%82">あ</a>
```

href inside the anchor:

```html
<a class="anchor" href="#%E3%81%82" aria-hidden="true"> ...あ
```
</details>

## Changes

- `CGI.escape` for URL-encoding
- Refactoring: Create Helper module
- Refactoring: Do not use `Nokogiri::HTML(parser.toc)`, use `parser.build_toc` instead