### PR TITLE
Add configuration to enable ordered list

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
   - [Skip TOC Section](#skip-toc-section)
   - [CSS Styling](#css-styling)
   - [Custom CSS Class](#custom-css-class)
+  - [Using Unordered/Ordered lists](#using-unorderedordered-lists)
 
 ## Installation
 
@@ -151,6 +152,7 @@ toc:
   sublist_class: ''
   item_class: toc-entry
   item_prefix: toc-
+  use_ordered_list: false
 ```
 
 ## Customization
@@ -245,3 +247,39 @@ toc:
   # Default is "toc-":
   item_prefix: item-
 ```
+
+### Using Unordered/Ordered lists
+
+By default the table of contents will be generated as an unordered list via `<ul></ul>` tags. This can be configured to use ordered lists instead `<ol></ol>`.
+This can be configured in `_config.yml`:
+
+```yml
+toc:
+  use_ordered_list: true # default is false
+```
+
+In order to change the list type, use the [list-style-type](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type) css property.
+Add a class to the `sublist_class` configuration to append it to the `ol` tags so that you can add the `list-style-type` property.
+
+Example
+
+```yml
+toc:
+  use_ordered_list: true
+  list_class: my-list-class
+  sublist_class: my-sublist-class
+```
+
+```css
+.my-list-class {
+  list-style-type: upper-alpha;
+}
+
+.my-sublist-class: {
+  list-style-type: lower-alpha;
+}
+```
+
+This will produce:
+
+![screenshot](https://user-images.githubusercontent.com/7675276/85813980-a0ea5a80-b719-11ea-9458-ccf9b86a778b.png)

--- a/lib/table_of_contents/configuration.rb
+++ b/lib/table_of_contents/configuration.rb
@@ -5,7 +5,8 @@ module Jekyll
     # jekyll-toc configuration class
     class Configuration
       attr_reader :toc_levels, :no_toc_class, :no_toc_section_class,
-                  :list_class, :sublist_class, :item_class, :item_prefix
+                  :list_class, :sublist_class, :item_class, :item_prefix,
+                  :use_ordered_list
 
       DEFAULT_CONFIG = {
         'min_level' => 1,
@@ -14,7 +15,8 @@ module Jekyll
         'list_class' => 'section-nav',
         'sublist_class' => '',
         'item_class' => 'toc-entry',
-        'item_prefix' => 'toc-'
+        'item_prefix' => 'toc-',
+        'use_ordered_list' => false
       }.freeze
 
       def initialize(options)
@@ -27,6 +29,7 @@ module Jekyll
         @sublist_class = options['sublist_class']
         @item_class = options['item_class']
         @item_prefix = options['item_prefix']
+        @use_ordered_list = options['use_ordered_list']
       end
 
       private

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -8,6 +8,9 @@ module Jekyll
     class Parser
       include ::Jekyll::TableOfContents::Helper
 
+      ORDERED_LIST_HTML_TAG = 'ol'
+      UNORDERED_LIST_HTML_TAG = 'ul'
+
       def initialize(html, options = {})
         @doc = Nokogiri::HTML::DocumentFragment.parse(html)
         @configuration = Configuration.new(options)
@@ -19,7 +22,7 @@ module Jekyll
       end
 
       def build_toc
-        %(<ul class="#{@configuration.list_class}">\n#{build_toc_list(@entries)}</ul>)
+        %(<#{list_tag} class="#{@configuration.list_class}">\n#{build_toc_list(@entries)}</#{list_tag}>)
       end
 
       def inject_anchors_into_html
@@ -74,7 +77,7 @@ module Jekyll
             next_i = i + 1
             if next_i < entries.count && entries[next_i][:h_num] > min_h_num
               nest_entries = get_nest_entries(entries[next_i, entries.count], min_h_num)
-              toc_list << %(\n<ul#{ul_attributes}>\n#{build_toc_list(nest_entries)}</ul>\n)
+              toc_list << %(\n<#{list_tag}#{ul_attributes}>\n#{build_toc_list(nest_entries)}</#{list_tag}>\n)
               i += nest_entries.count
             end
             # Add the closing tag for the current entry in the list
@@ -120,6 +123,14 @@ module Jekyll
 
       def ul_attributes
         @ul_attributes ||= @configuration.sublist_class.empty? ? '' : %( class="#{@configuration.sublist_class}")
+      end
+
+      def use_ordered_list?
+        @configuration.use_ordered_list
+      end
+
+      def list_tag
+        use_ordered_list? ? ORDERED_LIST_HTML_TAG : UNORDERED_LIST_HTML_TAG
       end
     end
   end

--- a/test/parser/test_ordered_list.rb
+++ b/test/parser/test_ordered_list.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TestOrderedList < Minitest::Test
+  include TestHelpers
+
+  def test_default_configuration
+    configuration = Jekyll::TableOfContents::Configuration.new({})
+
+    assert_equal configuration.use_ordered_list, false
+  end
+
+  def test_disabled_ordered_list
+    configuration = Jekyll::TableOfContents::Configuration.new('use_ordered_list' => false)
+
+    assert_equal configuration.use_ordered_list, false
+  end
+
+  def test_enabled_ordered_list
+    configuration = Jekyll::TableOfContents::Configuration.new('use_ordered_list' => true)
+
+    assert_equal configuration.use_ordered_list, true
+  end
+
+  def test_basic_ordered_list_top_heading
+    parse_with_ordered_list
+    html = @parser.toc
+
+    assert_match(/^<ol class="section-nav">/, html)
+  end
+
+  def test_ordered_list_sub_headings
+    parse_with_ordered_list
+    html = @parser.toc
+
+    assert_match(/<ol>\n<li class="toc-entry/, html)
+  end
+
+  def test_ordered_list_top_heading_with_classes
+    parse_with_ordered_list_and_classes
+    html = @parser.toc
+
+    assert_match(/^<ol class="top-list-class">/, html)
+  end
+
+  def test_ordered_list_sub_headings_with_classes
+    parse_with_ordered_list_and_classes
+    html = @parser.toc
+
+    assert_match(/<ol class="sublist-class">/, html)
+  end
+
+  def test_ordered_list_subheadings_with_classes_nested_structure
+    parse_with_ordered_list_and_classes
+    html = @parser.toc
+
+    occurrences = html.scan(/<ol class="sublist-class">/).count
+
+    assert_equal occurrences, 5
+  end
+  
+  private
+
+  def parse_with_ordered_list
+    read_html_and_create_parser('use_ordered_list' => true)
+  end
+
+  def parse_with_ordered_list_and_classes
+    read_html_and_create_parser(
+      'use_ordered_list' => true,
+      'list_class' => 'top-list-class',
+      'sublist_class' => 'sublist-class'
+    )
+  end
+end

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -12,6 +12,7 @@ class TestConfiguration < Minitest::Test
     assert_equal configuration.sublist_class, ''
     assert_equal configuration.item_class, 'toc-entry'
     assert_equal configuration.item_prefix, 'toc-'
+    assert_equal configuration.use_ordered_list, false
   end
 
   def test_type_error
@@ -23,5 +24,6 @@ class TestConfiguration < Minitest::Test
     assert_equal configuration.sublist_class, ''
     assert_equal configuration.item_class, 'toc-entry'
     assert_equal configuration.item_prefix, 'toc-'
+    assert_equal configuration.use_ordered_list, false
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,7 +20,7 @@ SIMPLE_HTML = <<~HTML
 HTML
 
 module TestHelpers
-  def read_html_and_create_parser
-    @parser = Jekyll::TableOfContents::Parser.new(SIMPLE_HTML)
+  def read_html_and_create_parser(options = {})
+    @parser = Jekyll::TableOfContents::Parser.new(SIMPLE_HTML, options)
   end
 end


### PR DESCRIPTION
## Overview

By default `jekyll-toc` generates the HTML using unordered lists. If users desire ordered lists for their table of contents they cannot do so easily. With the changes below, the default behavior of using unordered lists will remain. However a new configuration option will toggle between `<ul></ul>` and `<ol></ol>` tags accordingly.

With the changes, users can add the existing custom classes to the top level heading and sub-headings separately. That way they can style the top heading and sub-headings separately. In this pass, I did not add the functionality to style multiple nested sub-headings but rather just all sub-headings using the existing configuration. If we feel that this would be useful, we can extend the current logic in the PR to inject classes similar to the list items so end users can style each sub-heading separately. This might be overkill so for simplicity, I have left it to just top level heading and sub-headings.

## Changes in PR

* Created new configuration option to enable ordered list through use_ordered_list input
* Default behaviour is false so users will continue to have ul tags
* Using existing class configuration, user can change styling on top ol tag and sub listing ol tags separately
* No ability to update styling on sub-nested ol tags separately but code is open to this change
* Added tests for new logic
* Update README with example of usage and render

### Related Issues

* Support for Ordered Lists - https://github.com/toshimaru/jekyll-toc/issues/71