### PR TITLE
Ordered list support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # jekyll-toc
 
 ![CI](https://github.com/toshimaru/jekyll-toc/workflows/CI/badge.svg)
-[![Gem Version](https://badge.fury.io/rb/jekyll-toc.svg)](http://badge.fury.io/rb/jekyll-toc)
+[![Gem Version](https://badge.fury.io/rb/jekyll-toc.svg)](https://badge.fury.io/rb/jekyll-toc)
 [![Code Climate](https://codeclimate.com/github/toshimaru/jekyll-toc/badges/gpa.svg)](https://codeclimate.com/github/toshimaru/jekyll-toc)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/cd56b207f327603662a1/test_coverage)](https://codeclimate.com/github/toshimaru/jekyll-toc/test_coverage)
 
@@ -152,7 +152,7 @@ toc:
   sublist_class: ''
   item_class: toc-entry
   item_prefix: toc-
-  use_ordered_list: false
+  ordered_list: false
 ```
 
 ## Customization
@@ -255,7 +255,7 @@ This can be configured in `_config.yml`:
 
 ```yml
 toc:
-  use_ordered_list: true # default is false
+  ordered_list: true # default is false
 ```
 
 In order to change the list type, use the [list-style-type](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type) css property.
@@ -265,7 +265,7 @@ Example
 
 ```yml
 toc:
-  use_ordered_list: true
+  ordered_list: true
   list_class: my-list-class
   sublist_class: my-sublist-class
 ```

--- a/README.md
+++ b/README.md
@@ -147,12 +147,12 @@ jekyll-toc generates an unordered list. The HTML output is as follows.
 toc:
   min_level: 1
   max_level: 6
+  ordered_list: false
   no_toc_section_class: no_toc_section
   list_class: section-nav
   sublist_class: ''
   item_class: toc-entry
   item_prefix: toc-
-  ordered_list: false
 ```
 
 ## Customization

--- a/lib/table_of_contents/configuration.rb
+++ b/lib/table_of_contents/configuration.rb
@@ -15,7 +15,7 @@ module Jekyll
         'list_class' => 'section-nav',
         'sublist_class' => '',
         'item_class' => 'toc-entry',
-        'item_prefix' => 'toc-',
+        'item_prefix' => 'toc-'
       }.freeze
 
       def initialize(options)

--- a/lib/table_of_contents/configuration.rb
+++ b/lib/table_of_contents/configuration.rb
@@ -6,7 +6,7 @@ module Jekyll
     class Configuration
       attr_reader :toc_levels, :no_toc_class, :no_toc_section_class,
                   :list_class, :sublist_class, :item_class, :item_prefix,
-                  :use_ordered_list
+                  :ordered_list
 
       DEFAULT_CONFIG = {
         'min_level' => 1,
@@ -16,7 +16,7 @@ module Jekyll
         'sublist_class' => '',
         'item_class' => 'toc-entry',
         'item_prefix' => 'toc-',
-        'use_ordered_list' => false
+        'ordered_list' => false
       }.freeze
 
       def initialize(options)
@@ -29,7 +29,7 @@ module Jekyll
         @sublist_class = options['sublist_class']
         @item_class = options['item_class']
         @item_prefix = options['item_prefix']
-        @use_ordered_list = options['use_ordered_list']
+        @ordered_list = options['ordered_list']
       end
 
       private

--- a/lib/table_of_contents/configuration.rb
+++ b/lib/table_of_contents/configuration.rb
@@ -4,32 +4,31 @@ module Jekyll
   module TableOfContents
     # jekyll-toc configuration class
     class Configuration
-      attr_reader :toc_levels, :no_toc_class, :no_toc_section_class,
-                  :list_class, :sublist_class, :item_class, :item_prefix,
-                  :ordered_list
+      attr_reader :toc_levels, :no_toc_class, :ordered_list, :no_toc_section_class,
+                  :list_class, :sublist_class, :item_class, :item_prefix
 
       DEFAULT_CONFIG = {
         'min_level' => 1,
         'max_level' => 6,
+        'ordered_list' => false,
         'no_toc_section_class' => 'no_toc_section',
         'list_class' => 'section-nav',
         'sublist_class' => '',
         'item_class' => 'toc-entry',
         'item_prefix' => 'toc-',
-        'ordered_list' => false
       }.freeze
 
       def initialize(options)
         options = generate_option_hash(options)
 
         @toc_levels = options['min_level']..options['max_level']
+        @ordered_list = options['ordered_list']
         @no_toc_class = 'no_toc'
         @no_toc_section_class = options['no_toc_section_class']
         @list_class = options['list_class']
         @sublist_class = options['sublist_class']
         @item_class = options['item_class']
         @item_prefix = options['item_prefix']
-        @ordered_list = options['ordered_list']
       end
 
       private

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -8,9 +8,6 @@ module Jekyll
     class Parser
       include ::Jekyll::TableOfContents::Helper
 
-      ORDERED_LIST_HTML_TAG = 'ol'
-      UNORDERED_LIST_HTML_TAG = 'ul'
-
       def initialize(html, options = {})
         @doc = Nokogiri::HTML::DocumentFragment.parse(html)
         @configuration = Configuration.new(options)
@@ -110,7 +107,7 @@ module Jekyll
       end
 
       def toc_headings_in_no_toc_section
-        if @configuration.no_toc_section_class.is_a? Array
+        if @configuration.no_toc_section_class.is_a?(Array)
           @configuration.no_toc_section_class.map { |cls| toc_headings_within(cls) }.join(',')
         else
           toc_headings_within(@configuration.no_toc_section_class)
@@ -126,7 +123,7 @@ module Jekyll
       end
 
       def list_tag
-        @list_tag ||= @configuration.ordered_list ? ORDERED_LIST_HTML_TAG : UNORDERED_LIST_HTML_TAG
+        @list_tag ||= @configuration.ordered_list ? 'ol' : 'ul'
       end
     end
   end

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -125,12 +125,8 @@ module Jekyll
         @ul_attributes ||= @configuration.sublist_class.empty? ? '' : %( class="#{@configuration.sublist_class}")
       end
 
-      def use_ordered_list?
-        @configuration.use_ordered_list
-      end
-
       def list_tag
-        use_ordered_list? ? ORDERED_LIST_HTML_TAG : UNORDERED_LIST_HTML_TAG
+        @list_tag ||= @configuration.ordered_list ? ORDERED_LIST_HTML_TAG : UNORDERED_LIST_HTML_TAG
       end
     end
   end

--- a/test/parser/test_ordered_list.rb
+++ b/test/parser/test_ordered_list.rb
@@ -8,19 +8,19 @@ class TestOrderedList < Minitest::Test
   def test_default_configuration
     configuration = Jekyll::TableOfContents::Configuration.new({})
 
-    assert_equal configuration.use_ordered_list, false
+    assert_equal configuration.ordered_list, false
   end
 
   def test_disabled_ordered_list
-    configuration = Jekyll::TableOfContents::Configuration.new('use_ordered_list' => false)
+    configuration = Jekyll::TableOfContents::Configuration.new('ordered_list' => false)
 
-    assert_equal configuration.use_ordered_list, false
+    assert_equal configuration.ordered_list, false
   end
 
   def test_enabled_ordered_list
-    configuration = Jekyll::TableOfContents::Configuration.new('use_ordered_list' => true)
+    configuration = Jekyll::TableOfContents::Configuration.new('ordered_list' => true)
 
-    assert_equal configuration.use_ordered_list, true
+    assert_equal configuration.ordered_list, true
   end
 
   def test_basic_ordered_list_top_heading
@@ -63,12 +63,12 @@ class TestOrderedList < Minitest::Test
   private
 
   def parse_with_ordered_list
-    read_html_and_create_parser('use_ordered_list' => true)
+    read_html_and_create_parser('ordered_list' => true)
   end
 
   def parse_with_ordered_list_and_classes
     read_html_and_create_parser(
-      'use_ordered_list' => true,
+      'ordered_list' => true,
       'list_class' => 'top-list-class',
       'sublist_class' => 'sublist-class'
     )

--- a/test/parser/test_ordered_list.rb
+++ b/test/parser/test_ordered_list.rb
@@ -59,7 +59,7 @@ class TestOrderedList < Minitest::Test
 
     assert_equal occurrences, 5
   end
-  
+
   private
 
   def parse_with_ordered_list

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class TestConfiguration < Minitest::Test
-  def test_default_conf1guration
+  def test_default_configuration
     configuration = Jekyll::TableOfContents::Configuration.new({})
 
     assert_equal configuration.toc_levels, 1..6
@@ -12,7 +12,7 @@ class TestConfiguration < Minitest::Test
     assert_equal configuration.sublist_class, ''
     assert_equal configuration.item_class, 'toc-entry'
     assert_equal configuration.item_prefix, 'toc-'
-    assert_equal configuration.use_ordered_list, false
+    assert_equal configuration.ordered_list, false
   end
 
   def test_type_error
@@ -24,6 +24,6 @@ class TestConfiguration < Minitest::Test
     assert_equal configuration.sublist_class, ''
     assert_equal configuration.item_class, 'toc-entry'
     assert_equal configuration.item_prefix, 'toc-'
-    assert_equal configuration.use_ordered_list, false
+    assert_equal configuration.ordered_list, false
   end
 end

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -7,23 +7,23 @@ class TestConfiguration < Minitest::Test
     configuration = Jekyll::TableOfContents::Configuration.new({})
 
     assert_equal configuration.toc_levels, 1..6
+    assert_equal configuration.ordered_list, false
     assert_equal configuration.no_toc_section_class, 'no_toc_section'
     assert_equal configuration.list_class, 'section-nav'
     assert_equal configuration.sublist_class, ''
     assert_equal configuration.item_class, 'toc-entry'
     assert_equal configuration.item_prefix, 'toc-'
-    assert_equal configuration.ordered_list, false
   end
 
   def test_type_error
     configuration = Jekyll::TableOfContents::Configuration.new('TypeError!')
 
     assert_equal configuration.toc_levels, 1..6
+    assert_equal configuration.ordered_list, false
     assert_equal configuration.no_toc_section_class, 'no_toc_section'
     assert_equal configuration.list_class, 'section-nav'
     assert_equal configuration.sublist_class, ''
     assert_equal configuration.item_class, 'toc-entry'
     assert_equal configuration.item_prefix, 'toc-'
-    assert_equal configuration.ordered_list, false
   end
 end


### PR DESCRIPTION
Follow up #117 . closes #71

## Changes

Based on https://github.com/toshimaru/jekyll-toc/pull/117#pullrequestreview-483034489, I added some changes:

- `use_ordered_list` -> `ordered_list `
- Memorize list_tag method