### PR TITLE
Configure GitHub Actions dependabot / Use actions/setup-ruby

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,14 @@
 version: 2
 updates:
   - package-ecosystem: "bundler"
-    directory: "/" # Location of package manifests
+    directory: "/"
     schedule:
       interval: "weekly"
+  reviewers:
+    - toshimaru
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  reviewers:
+    - toshimaru

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby }}
-      uses: eregon/use-ruby-action@master
+      uses: actions/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: bundle install

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby }}
-        uses: eregon/use-ruby-action@master
+        uses: actions/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: bundle install

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby }}
-        uses: eregon/use-ruby-action@master
+        uses: actions/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: bundle install


### PR DESCRIPTION
- Configure GitHub Actions dependabot 
- Use actions/setup-ruby instead of eregon/use-ruby-action