### PR TITLE
Replace octicon element with a static unicode symbol

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,8 @@ Metrics/ClassLength:
 
 Naming/FileName:
   Enabled: false
+Naming/VariableNumber:
+  Enabled: false
 
 Layout/LineLength:
   Enabled: false

--- a/lib/table_of_contents/configuration.rb
+++ b/lib/table_of_contents/configuration.rb
@@ -5,7 +5,7 @@ module Jekyll
     # jekyll-toc configuration class
     class Configuration
       attr_reader :toc_levels, :no_toc_class, :ordered_list, :no_toc_section_class,
-                  :list_class, :sublist_class, :item_class, :item_prefix
+                  :list_class, :sublist_class, :item_class, :item_prefix, :anchor_symbol
 
       DEFAULT_CONFIG = {
         'min_level' => 1,
@@ -15,7 +15,8 @@ module Jekyll
         'list_class' => 'section-nav',
         'sublist_class' => '',
         'item_class' => 'toc-entry',
-        'item_prefix' => 'toc-'
+        'item_prefix' => 'toc-',
+        'anchor_symbol' => ' &#128279;'
       }.freeze
 
       def initialize(options)
@@ -29,6 +30,7 @@ module Jekyll
         @sublist_class = options['sublist_class']
         @item_class = options['item_class']
         @item_prefix = options['item_prefix']
+        @anchor_symbol = options['anchor_symbol']
       end
 
       private

--- a/lib/table_of_contents/configuration.rb
+++ b/lib/table_of_contents/configuration.rb
@@ -16,7 +16,7 @@ module Jekyll
         'sublist_class' => '',
         'item_class' => 'toc-entry',
         'item_prefix' => 'toc-',
-        'anchor_symbol' => ' &#128279;'
+        'anchor_symbol' => ' &#128279;' # with leading space
       }.freeze
 
       def initialize(options)

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -32,7 +32,7 @@ module Jekyll
                     
           # Add link icon after text
           entry[:header_content].add_next_sibling(
-            %(<a class="anchor" href="##{entry[:id]}" aria-hidden="true">&nbsp;&#128279;</a>)
+            %(<a class="anchor" href="##{entry[:id]}"aria-hidden="true">#{@configuration.anchor_symbol}</a>)
           )
         end
 

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -25,11 +25,11 @@ module Jekyll
       def inject_anchors_into_html
         @entries.each do |entry|
           # NOTE: `entry[:id]` is automatically URL encoded by Nokogiri
-          
+
           # entry[:header_content].add_previous_sibling(
           #   %(<a class="anchor" href="##{entry[:id]}" aria-hidden="true"><span class="octicon octicon-link"></span></a>)
           # )
-                    
+
           # Add link icon after text
           entry[:header_content].add_next_sibling(
             %(<a class="anchor" href="##{entry[:id]}"aria-hidden="true">#{@configuration.anchor_symbol}</a>)

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -25,8 +25,14 @@ module Jekyll
       def inject_anchors_into_html
         @entries.each do |entry|
           # NOTE: `entry[:id]` is automatically URL encoded by Nokogiri
-          entry[:header_content].add_previous_sibling(
-            %(<a class="anchor" href="##{entry[:id]}" aria-hidden="true"><span class="octicon octicon-link"></span></a>)
+          
+          # entry[:header_content].add_previous_sibling(
+          #   %(<a class="anchor" href="##{entry[:id]}" aria-hidden="true"><span class="octicon octicon-link"></span></a>)
+          # )
+                    
+          # Add link icon after text
+          entry[:header_content].add_next_sibling(
+            %(<a class="anchor" href="##{entry[:id]}" aria-hidden="true">&nbsp;&#128279;</a>)
           )
         end
 

--- a/test/parser/test_inject_anchors_filter.rb
+++ b/test/parser/test_inject_anchors_filter.rb
@@ -13,7 +13,7 @@ class TestInjectAnchorsFilter < Minitest::Test
     html = @parser.inject_anchors_into_html
 
     # assert_match(%r{<a class="anchor" href="#simple-h1" aria-hidden="true"><span.*span></a>Simple H1}, html)
-    assert_match(%r{Simple H1<a class="anchor" href="#simple-h1" aria-hidden="true"> 🔗<\/a>}, html)
+    assert_match(%r{Simple H1<a class="anchor" href="#simple-h1" aria-hidden="true"> 🔗</a>}, html)
   end
 
   def test_does_not_inject_toc

--- a/test/parser/test_inject_anchors_filter.rb
+++ b/test/parser/test_inject_anchors_filter.rb
@@ -12,7 +12,8 @@ class TestInjectAnchorsFilter < Minitest::Test
   def test_injects_anchors_into_content
     html = @parser.inject_anchors_into_html
 
-    assert_match(%r{<a class="anchor" href="#simple-h1" aria-hidden="true"><span.*span></a>Simple H1}, html)
+    # assert_match(%r{<a class="anchor" href="#simple-h1" aria-hidden="true"><span.*span></a>Simple H1}, html)
+    assert_match(%r{Simple H1<a class="anchor" href="#simple-h1" aria-hidden="true"> 🔗<\/a>}, html)
   end
 
   def test_does_not_inject_toc

--- a/test/parser/test_toc_filter.rb
+++ b/test/parser/test_toc_filter.rb
@@ -12,7 +12,7 @@ class TestTOCFilter < Minitest::Test
   def test_injects_anchors
     html = @parser.toc
 
-    assert_match(%r{<a class="anchor" href="#simple-h1" aria-hidden="true"><span.*span></a>Simple H1}, html)
+    assert_match(%r{Simple H1<a class="anchor" href="#simple-h1" aria-hidden="true"> 🔗</a>}, html)
   end
 
   def test_nested_toc

--- a/test/parser/test_various_toc_html.rb
+++ b/test/parser/test_various_toc_html.rb
@@ -171,9 +171,9 @@ class TestVariousTocHtml < Minitest::Test
 
     assert_equal(expected, parser.build_toc)
     html_with_anchors = parser.inject_anchors_into_html
-    assert_match(%r{<a class="anchor" href="#%E3%81%82" aria-hidden="true"><span.*span></a>あ}, html_with_anchors)
-    assert_match(%r{<a class="anchor" href="#%E3%81%84" aria-hidden="true"><span.*span></a>い}, html_with_anchors)
-    assert_match(%r{<a class="anchor" href="#%E3%81%86" aria-hidden="true"><span.*span></a>う}, html_with_anchors)
+    assert_match(%r{あ<a class="anchor" href="#%E3%81%82" aria-hidden="true"> 🔗</a>}, html_with_anchors)
+    assert_match(%r{い<a class="anchor" href="#%E3%81%84" aria-hidden="true"> 🔗</a>}, html_with_anchors)
+    assert_match(%r{う<a class="anchor" href="#%E3%81%86" aria-hidden="true"> 🔗</a>}, html_with_anchors)
   end
 
   # ref. https://github.com/toshimaru/jekyll-toc/issues/45


### PR DESCRIPTION
There was a octicon span element, this is now replaced by the configure able `anchor_symbol` unicode link symbol `&#128279;`

The symbol is placed behind the headline, the octicon span was placed before the headline

Fixes #24 