### PR TITLE
Support Ruby 3 / Drop Jekyll v3.8 / Drop Ruby v2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ jobs:
       matrix:
         ruby: [2.4, 2.5, 2.6, 2.7]
         gemfile:
-          - gemfiles/jekyll_3.8.gemfile
           - gemfiles/jekyll_3.9.gemfile
           - gemfiles/jekyll_4.0.gemfile
           - gemfiles/jekyll_4.1.gemfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7]
+        ruby: [2.4, 2.5, 2.6, 2.7, 3.0]
         gemfile:
           - gemfiles/jekyll_3.9.gemfile
           - gemfiles/jekyll_4.0.gemfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby }}
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: bundle install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,19 +4,12 @@ jobs:
   build:
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7, 3.0]
+        ruby: [2.5, 2.6, 2.7, 3.0]
         gemfile:
           - gemfiles/jekyll_3.9.gemfile
           - gemfiles/jekyll_4.0.gemfile
           - gemfiles/jekyll_4.1.gemfile
           - gemfiles/jekyll_4.2.gemfile
-        exclude:
-        - ruby: 2.4
-          gemfile: gemfiles/jekyll_4.0.gemfile
-        - ruby: 2.4
-          gemfile: gemfiles/jekyll_4.1.gemfile
-        - ruby: 2.4
-          gemfile: gemfiles/jekyll_4.2.gemfile
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby }}
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: bundle install

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ruby: [2.7]
+        ruby: [3.0]
     runs-on: ubuntu-latest
     name: coverage
     steps:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby }}
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: bundle install

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ruby: [2.7]
+        ruby: [3.0]
     runs-on: ubuntu-latest
     name: rubocop
     steps:

--- a/jekyll-toc.gemspec
+++ b/jekyll-toc.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.4'
 
-  spec.add_dependency 'jekyll', '>= 3.8'
+  spec.add_dependency 'jekyll', '>= 3.9'
   spec.add_dependency 'nokogiri', '~> 1.10'
 end

--- a/lib/table_of_contents/version.rb
+++ b/lib/table_of_contents/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   module TableOfContents
-    VERSION = '0.16.1'
+    VERSION = '0.17.0'
   end
 end


### PR DESCRIPTION
Closes #139

- Use ruby/setup-ruby and support Ruby 3
- Drop Jekyll v3.8
- Drop Ruby v2.4