### PR TITLE
Add  `inject_destination_anchors` filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,15 @@ They are of the form:
 This is only useful when the TOC itself should be placed at some other
 location with the `toc_only` filter.
 
+#### `inject_destination_anchors` filter
+
+```html
+<a class="anchor" id="#heading1-1"></a>
+```
+
+Inserts destination anchors alongside header tags. Useful if you are not using markdown (which does this automatically). Outputs HTML with destination anchor tags.
+
+
 ## Generated HTML
 
 jekyll-toc generates an unordered list by default. The HTML output is as follows.

--- a/lib/jekyll-toc.rb
+++ b/lib/jekyll-toc.rb
@@ -31,6 +31,12 @@ module Jekyll
       TableOfContents::Parser.new(html, toc_config).inject_anchors_into_html
     end
 
+    def inject_destination_anchors(html)
+      return html unless toc_enabled?
+
+      TableOfContents::Parser.new(html, toc_config).inject_destination_anchors_into_html
+    end
+
     def toc(html)
       return html unless toc_enabled?
 

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -33,6 +33,17 @@ module Jekyll
         @doc.inner_html
       end
 
+      def inject_destination_anchors_into_html
+        @entries.each do |entry|
+          # NOTE: `entry[:id]` is automatically URL encoded by Nokogiri
+          entry[:header_content].add_previous_sibling(
+            %(<a class="anchor" id="#{entry[:id]}"></a>)
+          )
+        end
+
+        @doc.inner_html
+      end
+
       private
 
       # parse logic is from html-pipeline toc_filter


### PR DESCRIPTION
Inserts destination anchors alongside header tags. Useful if you are not using markdown (which does this automatically). Outputs HTML with destination anchor tags.

I needed this functionality to get it working in my project which uses headless CMS (Contentful).