### PR TITLE
Test against latest Ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7, 3.0, 3.1, head]
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', head]
         gemfile:
           - gemfiles/jekyll_3.9.gemfile
           - gemfiles/jekyll_4.0.gemfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7, 3.0]
+        ruby: [2.5, 2.6, 2.7, 3.0, 3.1, head]
         gemfile:
           - gemfiles/jekyll_3.9.gemfile
           - gemfiles/jekyll_4.0.gemfile


### PR DESCRIPTION
Just testing with Ruby 3.2 and there seems to be some kwargs issues:

~~~
  1) Error:
TestTableOfContentsTag#test_toc_tag:
ArgumentError: unknown keywords: page, site
    /builddir/build/BUILD/jekyll-toc-0.17.1/usr/share/gems/gems/jekyll-toc-0.17.1/test/test_toc_tag.rb:15:in `initialize'
    /builddir/build/BUILD/jekyll-toc-0.17.1/usr/share/gems/gems/jekyll-toc-0.17.1/test/test_toc_tag.rb:15:in `new'
    /builddir/build/BUILD/jekyll-toc-0.17.1/usr/share/gems/gems/jekyll-toc-0.17.1/test/test_toc_tag.rb:15:in `test_toc_tag'
~~~

Therefore I thought, enabling CI against more recent version of Ruby could be good first step to have this addressed.