### PR TITLE
test: use hash explicitly for Struct initializer for ruby 3.2

### DIFF
--- a/test/test_jekyll-toc.rb
+++ b/test/test_jekyll-toc.rb
@@ -40,13 +40,13 @@ class TestTableOfContentsFilter < Minitest::Test
   private
 
   def disable_toc_context
-    Struct.new(:registers).new(page: { 'toc' => false })
+    Struct.new(:registers).new({page: { 'toc' => false }})
   end
 
   def enable_toc_context
-    Struct.new(:registers).new(
+    Struct.new(:registers).new({
       page: { 'toc' => true },
       site: Struct.new(:config).new({ 'toc' => false })
-    )
+    })
   end
 end

--- a/test/test_toc_tag.rb
+++ b/test/test_toc_tag.rb
@@ -12,16 +12,16 @@ class TestTableOfContentsTag < Minitest::Test
   end
 
   def test_toc_tag
-    context = @stubbed_context.new(
+    context = @stubbed_context.new({
       page: @stubbed_context2.new({ 'toc' => false }, '<h1>test</h1>'),
       site: @stubbed_context1.new({ 'toc' => nil })
-    )
+    })
     tag = Jekyll::TocTag.parse('toc_tag', '', Tokenizer.new(''), ParseContext.new)
     assert_equal(%(<ul id="toc" class="section-nav">\n<li class="toc-entry toc-h1"><a href="#test">test</a></li>\n</ul>), tag.render(context))
   end
 
   def test_toc_tag_returns_empty_string
-    context = @stubbed_context.new(page: { 'toc' => false })
+    context = @stubbed_context.new({page: { 'toc' => false }})
     tag = Jekyll::TocTag.parse('toc_tag', '', Tokenizer.new(''), ParseContext.new)
     assert_empty tag.render(context)
   end


### PR DESCRIPTION
ruby 3.2 changes Struct.new behavior so that keyword_init option is enabled by default. This means that keyword argument passed to the initializer of Struct is now treated differently with ruby3.2.

To avoid behavior change in jekyll-toc test code, use hash explicitly for Struct initializer.

Closes #164 .