### PR TITLE
chore: Fix rubocop errors

### DIFF
--- a/test/parser/test_invalid_options.rb
+++ b/test/parser/test_invalid_options.rb
@@ -12,21 +12,25 @@ class TestInvalidOptions < Minitest::Test
 
   def test_option_is_nil
     parser = Jekyll::TableOfContents::Parser.new(BASE_HTML, nil)
+
     assert_equal(EXPECTED_HTML, parser.build_toc)
   end
 
   def test_option_is_epmty_string
     parser = Jekyll::TableOfContents::Parser.new(BASE_HTML, '')
+
     assert_equal(EXPECTED_HTML, parser.build_toc)
   end
 
   def test_option_is_string
     parser = Jekyll::TableOfContents::Parser.new(BASE_HTML, 'string')
+
     assert_equal(EXPECTED_HTML, parser.build_toc)
   end
 
   def test_option_is_array
     parser = Jekyll::TableOfContents::Parser.new(BASE_HTML, [])
+
     assert_equal(EXPECTED_HTML, parser.build_toc)
   end
 end

--- a/test/parser/test_toc_filter.rb
+++ b/test/parser/test_toc_filter.rb
@@ -25,6 +25,7 @@ class TestTOCFilter < Minitest::Test
                         .css('li.toc-h5')
                         .css('li.toc-h6')
                         .text
+
     assert_equal('Simple H6', nested_h6_text)
   end
 

--- a/test/parser/test_various_toc_html.rb
+++ b/test/parser/test_various_toc_html.rb
@@ -171,6 +171,7 @@ class TestVariousTocHtml < Minitest::Test
 
     assert_equal(expected, parser.build_toc)
     html_with_anchors = parser.inject_anchors_into_html
+
     assert_match(%r{<a class="anchor" href="#%E3%81%82" aria-hidden="true"><span.*span></a>あ}, html_with_anchors)
     assert_match(%r{<a class="anchor" href="#%E3%81%84" aria-hidden="true"><span.*span></a>い}, html_with_anchors)
     assert_match(%r{<a class="anchor" href="#%E3%81%86" aria-hidden="true"><span.*span></a>う}, html_with_anchors)
@@ -234,6 +235,7 @@ class TestVariousTocHtml < Minitest::Test
     assert_equal(expected, parser.build_toc)
 
     html = parser.inject_anchors_into_html
+
     assert_match(%r{<h1>.+</h1>}m, html)
     assert_match(%r{<h3>.+</h3>}m, html)
     assert_match(%r{<h6>.+</h6>}m, html)
@@ -269,6 +271,7 @@ class TestVariousTocHtml < Minitest::Test
     assert_equal(expected, parser.build_toc)
 
     html = parser.inject_anchors_into_html
+
     assert_match(%r{<h1>.+</h1>}m, html)
     assert_match(%r{<h3>.+</h3>}m, html)
     assert_match(%r{<h6>.+</h6>}m, html)
@@ -306,6 +309,7 @@ class TestVariousTocHtml < Minitest::Test
     assert_equal(expected, parser.build_toc)
 
     html = parser.inject_anchors_into_html
+
     assert_match(%r{<h1>.+</h1>}m, html)
     assert_match(%r{<h3>.+</h3>}m, html)
     assert_match(%r{<h6>.+</h6>}m, html)
@@ -330,6 +334,7 @@ class TestVariousTocHtml < Minitest::Test
     assert_equal(expected, parser.build_toc)
 
     html = parser.inject_anchors_into_html
+
     assert_includes(html, %(<a class="anchor" href="#h1" aria-hidden="true">))
     assert_includes(html, %(<a class="anchor" href="#second" aria-hidden="true">))
     assert_includes(html, %(<a class="anchor" href="#third" aria-hidden="true">))

--- a/test/test_jekyll-toc.rb
+++ b/test/test_jekyll-toc.rb
@@ -9,44 +9,50 @@ class TestTableOfContentsFilter < Minitest::Test
 
   def test_toc_only
     @context = disable_toc_context
+
     assert_empty toc_only(DUMMY_HTML)
   end
 
   def test_inject_anchors
     @context = disable_toc_context
+
     assert_equal DUMMY_HTML, inject_anchors(DUMMY_HTML)
   end
 
   def test_toc
     @context = disable_toc_context
+
     assert_equal DUMMY_HTML, toc(DUMMY_HTML)
   end
 
   def test_toc_only2
     @context = enable_toc_context
+
     assert_equal %(<ul id="toc" class="section-nav">\n</ul>), toc_only(DUMMY_HTML)
   end
 
   def test_inject_anchors2
     @context = enable_toc_context
+
     assert_equal DUMMY_HTML, inject_anchors(DUMMY_HTML)
   end
 
   def test_toc2
     @context = enable_toc_context
+
     assert_equal %(<ul id="toc" class="section-nav">\n</ul>#{DUMMY_HTML}), toc(DUMMY_HTML)
   end
 
   private
 
   def disable_toc_context
-    Struct.new(:registers).new({page: { 'toc' => false }})
+    Struct.new(:registers).new({ page: { 'toc' => false } })
   end
 
   def enable_toc_context
     Struct.new(:registers).new({
-      page: { 'toc' => true },
-      site: Struct.new(:config).new({ 'toc' => false })
-    })
+                                 page: { 'toc' => true },
+                                 site: Struct.new(:config).new({ 'toc' => false })
+                               })
   end
 end

--- a/test/test_toc_tag.rb
+++ b/test/test_toc_tag.rb
@@ -13,16 +13,18 @@ class TestTableOfContentsTag < Minitest::Test
 
   def test_toc_tag
     context = @stubbed_context.new({
-      page: @stubbed_context2.new({ 'toc' => false }, '<h1>test</h1>'),
-      site: @stubbed_context1.new({ 'toc' => nil })
-    })
+                                     page: @stubbed_context2.new({ 'toc' => false }, '<h1>test</h1>'),
+                                     site: @stubbed_context1.new({ 'toc' => nil })
+                                   })
     tag = Jekyll::TocTag.parse('toc_tag', '', Tokenizer.new(''), ParseContext.new)
+
     assert_equal(%(<ul id="toc" class="section-nav">\n<li class="toc-entry toc-h1"><a href="#test">test</a></li>\n</ul>), tag.render(context))
   end
 
   def test_toc_tag_returns_empty_string
-    context = @stubbed_context.new({page: { 'toc' => false }})
+    context = @stubbed_context.new({ page: { 'toc' => false } })
     tag = Jekyll::TocTag.parse('toc_tag', '', Tokenizer.new(''), ParseContext.new)
+
     assert_empty tag.render(context)
   end
 end


### PR DESCRIPTION
Fix rubocop errors by running:

```console
$ bundle exec rubocop -a
```