### PR TITLE
Test against Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,16 @@
 name: CI
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
 jobs:
-  build:
+  test:
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', head]
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
         gemfile:
           - gemfiles/jekyll_3.9.gemfile
           - gemfiles/jekyll_4.0.gemfile
@@ -14,11 +20,11 @@ jobs:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Ruby ${{ matrix.ruby }}
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
-    - name: Run Test
-      run: bundle exec rake
+      - uses: actions/checkout@v3
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run Test
+        run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7, 3.0, 3.1, head]
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', head]
         gemfile:
           - gemfiles/jekyll_3.9.gemfile
           - gemfiles/jekyll_4.0.gemfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7, 3.0]
+        ruby: [2.5, 2.6, 2.7, 3.0, 3.1, head]
         gemfile:
           - gemfiles/jekyll_3.9.gemfile
           - gemfiles/jekyll_4.0.gemfile

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,18 +1,20 @@
 name: Coverage
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
 jobs:
-  build:
-    strategy:
-      matrix:
-        ruby: [3.0]
+  coverage:
     runs-on: ubuntu-latest
-    name: coverage
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Ruby ${{ matrix.ruby }}
+      - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: 3.2
           bundler-cache: true
       - uses: paambaati/codeclimate-action@v3.2.0
         env:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,18 +1,20 @@
 name: RuboCop
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
 jobs:
-  build:
-    strategy:
-      matrix:
-        ruby: [3.0]
+  rubocop:
     runs-on: ubuntu-latest
-    name: rubocop
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Ruby ${{ matrix.ruby }}
+      - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: 3.2
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rubocop


### PR DESCRIPTION
## Description

Let's support Ruby 3.2.

closes #162

## Changes
- CI against Ruby 3.2
- cherry-pick commits in #162.
- Use Ruby 3.2 for coverage and rubocop


