### PR TITLE
Drop Ruby 2.5 support / CI against Jekyll 4.3 / Refactoring `gemspec` file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
           - gemfiles/jekyll_4.0.gemfile
           - gemfiles/jekyll_4.1.gemfile
           - gemfiles/jekyll_4.2.gemfile
+          - gemfiles/jekyll_4.3.gemfile
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2']
         gemfile:
           - gemfiles/jekyll_3.9.gemfile
           - gemfiles/jekyll_4.0.gemfile

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   NewCops: enable
   Exclude:
     - "*.gemspec"

--- a/Appraisals
+++ b/Appraisals
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-SUPPORTED_VERSIONS = %w[3.9 4.0 4.1 4.2].freeze
+SUPPORTED_VERSIONS = %w[3.9 4.0 4.1 4.2 4.3].freeze
 
 SUPPORTED_VERSIONS.each do |version|
   appraise "jekyll-#{version}" do

--- a/gemfiles/jekyll_3.9.gemfile
+++ b/gemfiles/jekyll_3.9.gemfile
@@ -11,7 +11,7 @@ gem "rubocop-minitest"
 gem "rubocop-performance"
 gem "rubocop-rake"
 gem "rubocop"
-gem "simplecov", "~> 0.21.2"
+gem "simplecov", "~> 0.22.0"
 gem "jekyll", "3.9"
 
 gemspec path: "../"

--- a/gemfiles/jekyll_4.0.gemfile
+++ b/gemfiles/jekyll_4.0.gemfile
@@ -11,7 +11,7 @@ gem "rubocop-minitest"
 gem "rubocop-performance"
 gem "rubocop-rake"
 gem "rubocop"
-gem "simplecov", "~> 0.21.2"
+gem "simplecov", "~> 0.22.0"
 gem "jekyll", "4.0"
 
 gemspec path: "../"

--- a/gemfiles/jekyll_4.2.gemfile
+++ b/gemfiles/jekyll_4.2.gemfile
@@ -11,7 +11,7 @@ gem "rubocop-minitest"
 gem "rubocop-performance"
 gem "rubocop-rake"
 gem "rubocop"
-gem "simplecov", "~> 0.21.2"
+gem "simplecov", "~> 0.22.0"
 gem "jekyll", "4.2"
 
 gemspec path: "../"

--- a/gemfiles/jekyll_4.3.gemfile
+++ b/gemfiles/jekyll_4.3.gemfile
@@ -12,6 +12,6 @@ gem "rubocop-performance"
 gem "rubocop-rake"
 gem "rubocop"
 gem "simplecov", "~> 0.22.0"
-gem "jekyll", "4.1"
+gem "jekyll", "4.3"
 
 gemspec path: "../"

--- a/jekyll-toc.gemspec
+++ b/jekyll-toc.gemspec
@@ -1,23 +1,32 @@
 # frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'table_of_contents/version'
+require_relative 'lib/table_of_contents/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'jekyll-toc'
   spec.version       = Jekyll::TableOfContents::VERSION
   spec.summary       = 'Jekyll Table of Contents plugin'
   spec.description   = 'Jekyll (Ruby static website generator) plugin which generates a Table of Contents for the page.'
-  spec.authors       = %w(toshimaru torbjoernk)
+  spec.authors       = %w[toshimaru torbjoernk]
   spec.email         = 'me@toshimaru.net'
-  spec.files         = `git ls-files -z`.split("\x0")
   spec.homepage      = 'https://github.com/toshimaru/jekyll-toc'
   spec.license       = 'MIT'
-  spec.test_files    = spec.files.grep(%r{^(test|spec)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.5'
+  spec.metadata['homepage_uri'] = spec.homepage
+  spec.metadata['source_code_uri'] = 'https://github.com/toshimaru/jekyll-toc'
+  spec.metadata['changelog_uri'] = 'https://github.com/toshimaru/jekyll-toc/releases'
+  spec.metadata['rubygems_mfa_required'] = 'true'
+
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  spec.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").reject do |f|
+      (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|circleci)|appveyor)})
+    end
+  end
+
+  spec.required_ruby_version = '>= 2.6'
 
   spec.add_dependency 'jekyll', '>= 3.9'
   spec.add_dependency 'nokogiri', '~> 1.11'

--- a/jekyll-toc.gemspec
+++ b/jekyll-toc.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6'
 
   spec.add_dependency 'jekyll', '>= 3.9'
-  spec.add_dependency 'nokogiri', '~> 1.11'
+  spec.add_dependency 'nokogiri', '~> 1.12'
 end


### PR DESCRIPTION
- Drop Ruby 2.5 support
- CI against Jekyll 4.3
- Refactoring `gemspec` file