### PR TITLE
Prevent the generation of empty anchor links

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ They are of the form:
 
 ```html
 <a class="anchor" href="#heading1-1" aria-hidden="true">
-  <span class="octicon octicon-link"></span>
+  <span class="octicon octicon-link">Link to Heading1 1 section</span>
 </a>
 ```
 

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -26,7 +26,7 @@ module Jekyll
         @entries.each do |entry|
           # NOTE: `entry[:id]` is automatically URL encoded by Nokogiri
           entry[:header_content].add_previous_sibling(
-            %(<a class="anchor" href="##{entry[:id]}" aria-hidden="true"><span class="octicon octicon-link"></span></a>)
+            %(<a class="anchor" href="##{entry[:id]}" aria-hidden="true"><span class="octicon octicon-link">Link to #{entry[:text]} section</span></a>)
           )
         end
 

--- a/test/parser/test_inject_anchors_filter.rb
+++ b/test/parser/test_inject_anchors_filter.rb
@@ -12,7 +12,7 @@ class TestInjectAnchorsFilter < Minitest::Test
   def test_injects_anchors_into_content
     html = @parser.inject_anchors_into_html
 
-    assert_match(%r{<a class="anchor" href="#simple-h1" aria-hidden="true"><span.*span></a>Simple H1}, html)
+    assert_match(%r{<a class="anchor" href="#simple-h1" aria-hidden="true"><span>Link to Simple H1 section<span></a>Simple H1}, html)
   end
 
   def test_does_not_inject_toc


### PR DESCRIPTION
Added content to the span containing the link icon so a11y is improved.

Fixes https://github.com/toshimaru/jekyll-toc/issues/175