### PR TITLE
Fix/empty links

### DIFF
--- a/lib/table_of_contents/configuration.rb
+++ b/lib/table_of_contents/configuration.rb
@@ -22,10 +22,10 @@ module Jekyll
       def initialize(options)
         options = generate_option_hash(options)
 
-        @toc_levels = options['min_level']..options['max_level']
+        @toc_levels = (options['min_level']..options['max_level']).to_a
         @ordered_list = options['ordered_list']
         @no_toc_class = 'no_toc'
-        @no_toc_section_class = options['no_toc_section_class']
+        @no_toc_section_class = Array(options['no_toc_section_class'])
         @list_id = options['list_id']
         @list_class = options['list_class']
         @sublist_class = options['sublist_class']

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -24,14 +24,10 @@ module Jekyll
 
       def inject_anchors_into_html
         @entries.each do |entry|
-          header = entry[:header_content]
-          header_content = header.inner_html
-          header.parent.inner_html = %(<a class="anchor" href="##{entry[:id]}" aria-hidden="true"><span class="octicon octicon-link"></span>#{header_content}</a>)
+          entry[:header_content].wrap(%(<a class="anchor" href="##{entry[:id]}" aria-hidden="true"><span class="octicon octicon-link"></span></a>))
         end
         @doc.inner_html
       end
-      
-      
 
       private
 

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -36,7 +36,7 @@ module Jekyll
       def parse_content
         headers = Hash.new(0)
 
-        entries = (@doc.css(toc_headings) - @doc.css(toc_headings_in_no_toc_section))
+        (@doc.css(toc_headings) - @doc.css(toc_headings_in_no_toc_section))
           .reject { |n| n.classes.include?(@configuration.no_toc_class) }
           .inject([]) do |entries, node|
           text = node.text
@@ -53,7 +53,6 @@ module Jekyll
             h_num: node.name.delete('h').to_i
           }
         end
-        entries
       end
 
       # Returns the list items for entries

--- a/lib/table_of_contents/parser.rb
+++ b/lib/table_of_contents/parser.rb
@@ -24,14 +24,14 @@ module Jekyll
 
       def inject_anchors_into_html
         @entries.each do |entry|
-          # NOTE: `entry[:id]` is automatically URL encoded by Nokogiri
-          entry[:header_content].add_previous_sibling(
-            %(<a class="anchor" href="##{entry[:id]}" aria-hidden="true"><span class="octicon octicon-link"></span></a>)
-          )
+          header = entry[:header_content]
+          header_content = header.inner_html
+          header.parent.inner_html = %(<a class="anchor" href="##{entry[:id]}" aria-hidden="true"><span class="octicon octicon-link"></span>#{header_content}</a>)
         end
-
         @doc.inner_html
       end
+      
+      
 
       private
 
@@ -40,7 +40,7 @@ module Jekyll
       def parse_content
         headers = Hash.new(0)
 
-        (@doc.css(toc_headings) - @doc.css(toc_headings_in_no_toc_section))
+        entries = (@doc.css(toc_headings) - @doc.css(toc_headings_in_no_toc_section))
           .reject { |n| n.classes.include?(@configuration.no_toc_class) }
           .inject([]) do |entries, node|
           text = node.text
@@ -57,6 +57,7 @@ module Jekyll
             h_num: node.name.delete('h').to_i
           }
         end
+        entries
       end
 
       # Returns the list items for entries

--- a/test/parser/test_inject_anchors_filter.rb
+++ b/test/parser/test_inject_anchors_filter.rb
@@ -11,15 +11,10 @@ class TestInjectAnchorsFilter < Minitest::Test
 
   def test_injects_anchors_into_content
     html = @parser.inject_anchors_into_html
-    #puts "START OF HTML #{html} END OF HTML IN TEST"
-    
-    (1..6).each do |level|
-      assert_match(
-        %r{<h#{level}><a class="anchor" href="#simple-h#{level}" aria-hidden="true"><span class="octicon octicon-link"></span>Simple H#{level}</a></h#{level}>},
-        html
-      )
-    end
+
+    assert_match(%r{<a class="anchor" href="#simple-h1" aria-hidden="true"><span.*span>Simple H1</a>}, html)
   end
+  
 
   def test_does_not_inject_toc
     html = @parser.inject_anchors_into_html

--- a/test/parser/test_inject_anchors_filter.rb
+++ b/test/parser/test_inject_anchors_filter.rb
@@ -11,8 +11,14 @@ class TestInjectAnchorsFilter < Minitest::Test
 
   def test_injects_anchors_into_content
     html = @parser.inject_anchors_into_html
-
-    assert_match(%r{<a class="anchor" href="#simple-h1" aria-hidden="true"><span.*span></a>Simple H1}, html)
+    #puts "START OF HTML #{html} END OF HTML IN TEST"
+    
+    (1..6).each do |level|
+      assert_match(
+        %r{<h#{level}><a class="anchor" href="#simple-h#{level}" aria-hidden="true"><span class="octicon octicon-link"></span>Simple H#{level}</a></h#{level}>},
+        html
+      )
+    end
   end
 
   def test_does_not_inject_toc

--- a/test/parser/test_toc_filter.rb
+++ b/test/parser/test_toc_filter.rb
@@ -12,7 +12,7 @@ class TestTOCFilter < Minitest::Test
   def test_injects_anchors
     html = @parser.toc
 
-    assert_match(%r{<a class="anchor" href="#simple-h1" aria-hidden="true"><span.*span></a>Simple H1}, html)
+    assert_match(%r{<a class="anchor" href="#simple-h1" aria-hidden="true"><span.*span>Simple H1</a>}, html)
   end
 
   def test_nested_toc

--- a/test/parser/test_various_toc_html.rb
+++ b/test/parser/test_various_toc_html.rb
@@ -172,9 +172,9 @@ class TestVariousTocHtml < Minitest::Test
     assert_equal(expected, parser.build_toc)
     html_with_anchors = parser.inject_anchors_into_html
 
-    assert_match(%r{<a class="anchor" href="#%E3%81%82" aria-hidden="true"><span.*span></a>あ}, html_with_anchors)
-    assert_match(%r{<a class="anchor" href="#%E3%81%84" aria-hidden="true"><span.*span></a>い}, html_with_anchors)
-    assert_match(%r{<a class="anchor" href="#%E3%81%86" aria-hidden="true"><span.*span></a>う}, html_with_anchors)
+    assert_match(%r{<a class="anchor" href="#%E3%81%82" aria-hidden="true"><span.*span>あ</a>}, html_with_anchors)
+    assert_match(%r{<a class="anchor" href="#%E3%81%84" aria-hidden="true"><span.*span>い</a>}, html_with_anchors)
+    assert_match(%r{<a class="anchor" href="#%E3%81%86" aria-hidden="true"><span.*span>う</a>}, html_with_anchors)
   end
 
   # ref. https://github.com/toshimaru/jekyll-toc/issues/45

--- a/test/test_configuration.rb
+++ b/test/test_configuration.rb
@@ -6,9 +6,9 @@ class TestConfiguration < Minitest::Test
   def test_default_configuration
     configuration = Jekyll::TableOfContents::Configuration.new({})
 
-    assert_equal(1..6, configuration.toc_levels)
+    assert_equal((1..6).to_a, configuration.toc_levels)
     refute(configuration.ordered_list)
-    assert_equal('no_toc_section', configuration.no_toc_section_class)
+    assert_equal(['no_toc_section'], configuration.no_toc_section_class)
     assert_equal('toc', configuration.list_id)
     assert_equal('section-nav', configuration.list_class)
     assert_equal('', configuration.sublist_class)
@@ -19,9 +19,9 @@ class TestConfiguration < Minitest::Test
   def test_type_error
     configuration = Jekyll::TableOfContents::Configuration.new('TypeError!')
 
-    assert_equal(1..6, configuration.toc_levels)
+    assert_equal((1..6).to_a, configuration.toc_levels)
     refute(configuration.ordered_list)
-    assert_equal('no_toc_section', configuration.no_toc_section_class)
+    assert_equal(['no_toc_section'], configuration.no_toc_section_class)
     assert_equal('toc', configuration.list_id)
     assert_equal('section-nav', configuration.list_class)
     assert_equal('', configuration.sublist_class)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,12 +11,12 @@ require 'jekyll'
 require 'jekyll-toc'
 
 SIMPLE_HTML = <<~HTML
-  <h1>Simple H1</h1>
-  <h2>Simple H2</h2>
-  <h3>Simple H3</h3>
-  <h4>Simple H4</h4>
-  <h5>Simple H5</h5>
-  <h6>Simple H6</h6>
+  <h1 id="simple-h1">Simple H1</h1>
+  <h2 id="simple-h2">Simple H2</h2>
+  <h3 id="simple-h3">Simple H3</h3>
+  <h4 id="simple-h4">Simple H4</h4>
+  <h5 id="simple-h5">Simple H5</h5>
+  <h6 id="simple-h6">Simple H6</h6>
 HTML
 
 module TestHelpers

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,12 +11,12 @@ require 'jekyll'
 require 'jekyll-toc'
 
 SIMPLE_HTML = <<~HTML
-  <h1 id="simple-h1">Simple H1</h1>
-  <h2 id="simple-h2">Simple H2</h2>
-  <h3 id="simple-h3">Simple H3</h3>
-  <h4 id="simple-h4">Simple H4</h4>
-  <h5 id="simple-h5">Simple H5</h5>
-  <h6 id="simple-h6">Simple H6</h6>
+  <h1>Simple H1</h1>
+  <h2>Simple H2</h2>
+  <h3>Simple H3</h3>
+  <h4>Simple H4</h4>
+  <h5>Simple H5</h5>
+  <h6>Simple H6</h6>
 HTML
 
 module TestHelpers


### PR DESCRIPTION
Please consider this pull request for an accessibility fix per [WCAG 2.1 standard](https://webaim.org/standards/wcag/checklist#sc2.4.4). 

The fix addresses the empty link issue described here: #175 , but is implemented a bit differently. 

``inject_anchors_into_html`` now wraps the header's content inside the ``<a></a>`` tags. The header text is still seen on page and complies with accessibility requirements. 

Tests were adjusted accordingly. 
Some syntax changes were introduced to configuration files due to tests failing. 

All comments and fixes to this PR are welcome. 