### PR TITLE
Adding support for per page and per post TOC min_level and max_level

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,23 @@ toc:
 
 The default heading range is from `<h1>` to `<h6>`.
 
+#### Per-Page TOC Level Override
+
+You can override the `min_level` and `max_level` settings for individual pages or posts by adding a `toc_config` key to the YAML front matter:
+
+```yml
+---
+layout: post
+title: "My Post"
+toc: true
+toc_config:
+  min_level: 2  # Override: Start from H2 for this page only
+  max_level: 4  # Override: Stop at H4 for this page only
+---
+```
+
+This is useful when you want different TOC depths for different types of content.
+
 ### Enable TOC by default
 
 You can enable TOC by default with [Front Matter Defaults](https://jekyllrb.com/docs/configuration/front-matter-defaults/):

--- a/lib/jekyll-toc.rb
+++ b/lib/jekyll-toc.rb
@@ -11,8 +11,16 @@ module Jekyll
       return '' unless context.registers[:page]['toc']
 
       content_html = context.registers[:page]['content']
-      toc_config = context.registers[:site].config['toc'] || {}
+      toc_config = merge_toc_config(context)
       TableOfContents::Parser.new(content_html, toc_config).build_toc
+    end
+
+    private
+
+    def merge_toc_config(context)
+      site_config = context.registers[:site].config['toc'] || {}
+      page_config = context.registers[:page]['toc_config'] || {}
+      site_config.merge(page_config)
     end
   end
 
@@ -44,7 +52,9 @@ module Jekyll
     end
 
     def toc_config
-      @context.registers[:site].config['toc'] || {}
+      site_config = @context.registers[:site].config['toc'] || {}
+      page_config = @context.registers[:page]['toc_config'] || {}
+      site_config.merge(page_config)
     end
   end
 end

--- a/test/test_page_config_override.rb
+++ b/test/test_page_config_override.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TestPageConfigOverride < Minitest::Test
+  include Liquid
+
+  def setup
+    @stubbed_context  = Struct.new(:registers)
+    @stubbed_context1 = Struct.new(:config)
+    @stubbed_context2 = Struct.new(:toc, :content, :toc_config)
+  end
+
+  def test_page_overrides_min_level
+    # Site config has min_level: 1, max_level: 6
+    # Page config overrides to min_level: 2
+    html_content = '<h1>H1 Title</h1><h2>H2 Title</h2><h3>H3 Title</h3>'
+
+    context = @stubbed_context.new({
+                                     page: @stubbed_context2.new(
+                                       true,
+                                       html_content,
+                                       { 'min_level' => 2 }
+                                     ),
+                                     site: @stubbed_context1.new({
+                                                                   'toc' => { 'min_level' => 1, 'max_level' => 6 }
+                                                                 })
+                                   })
+
+    tag = Jekyll::TocTag.parse('toc_tag', '', Tokenizer.new(''), ParseContext.new)
+    result = tag.render(context)
+
+    # H1 should not be in TOC due to min_level override
+    refute_match(/H1 Title/, result)
+    # H2 and H3 should be in TOC
+    assert_match(/H2 Title/, result)
+    assert_match(/H3 Title/, result)
+  end
+
+  def test_page_overrides_max_level
+    # Site config has min_level: 1, max_level: 6
+    # Page config overrides to max_level: 2
+    html_content = '<h1>H1 Title</h1><h2>H2 Title</h2><h3>H3 Title</h3>'
+
+    context = @stubbed_context.new({
+                                     page: @stubbed_context2.new(
+                                       true,
+                                       html_content,
+                                       { 'max_level' => 2 }
+                                     ),
+                                     site: @stubbed_context1.new({
+                                                                   'toc' => { 'min_level' => 1, 'max_level' => 6 }
+                                                                 })
+                                   })
+
+    tag = Jekyll::TocTag.parse('toc_tag', '', Tokenizer.new(''), ParseContext.new)
+    result = tag.render(context)
+
+    # H1 and H2 should be in TOC
+    assert_match(/H1 Title/, result)
+    assert_match(/H2 Title/, result)
+    # H3 should not be in TOC due to max_level override
+    refute_match(/H3 Title/, result)
+  end
+
+  def test_page_overrides_both_min_and_max_level
+    # Page config overrides both min and max level to show only H2
+    html_content = '<h1>H1 Title</h1><h2>H2 Title</h2><h3>H3 Title</h3>'
+
+    context = @stubbed_context.new({
+                                     page: @stubbed_context2.new(
+                                       true,
+                                       html_content,
+                                       { 'min_level' => 2, 'max_level' => 2 }
+                                     ),
+                                     site: @stubbed_context1.new({
+                                                                   'toc' => { 'min_level' => 1, 'max_level' => 6 }
+                                                                 })
+                                   })
+
+    tag = Jekyll::TocTag.parse('toc_tag', '', Tokenizer.new(''), ParseContext.new)
+    result = tag.render(context)
+
+    # Only H2 should be in TOC
+    refute_match(/H1 Title/, result)
+    assert_match(/H2 Title/, result)
+    refute_match(/H3 Title/, result)
+  end
+
+  def test_no_page_config_uses_site_config
+    # When no page config is provided, use site defaults
+    html_content = '<h1>H1 Title</h1><h2>H2 Title</h2>'
+
+    context = @stubbed_context.new({
+                                     page: @stubbed_context2.new(
+                                       true,
+                                       html_content,
+                                       nil # no page config
+                                     ),
+                                     site: @stubbed_context1.new({
+                                                                   'toc' => { 'min_level' => 1, 'max_level' => 6 }
+                                                                 })
+                                   })
+
+    tag = Jekyll::TocTag.parse('toc_tag', '', Tokenizer.new(''), ParseContext.new)
+    result = tag.render(context)
+
+    # Both H1 and H2 should be in TOC with site defaults
+    assert_match(/H1 Title/, result)
+    assert_match(/H2 Title/, result)
+  end
+
+  def test_page_config_with_other_options
+    # Page can override min/max level while keeping other site config
+    html_content = '<h2>H2 Title</h2><h3>H3 Title</h3>'
+
+    context = @stubbed_context.new({
+                                     page: @stubbed_context2.new(
+                                       true,
+                                       html_content,
+                                       { 'min_level' => 2, 'max_level' => 3 }
+                                     ),
+                                     site: @stubbed_context1.new({
+                                                                   'toc' => {
+                                                                     'min_level' => 1,
+                                                                     'max_level' => 6,
+                                                                     'list_class' => 'custom-toc'
+                                                                   }
+                                                                 })
+                                   })
+
+    tag = Jekyll::TocTag.parse('toc_tag', '', Tokenizer.new(''), ParseContext.new)
+    result = tag.render(context)
+
+    # Should use page's min/max levels but keep site's list_class
+    assert_match(/H2 Title/, result)
+    assert_match(/H3 Title/, result)
+    assert_match(/class="custom-toc"/, result)
+  end
+end

--- a/test/test_toc_tag.rb
+++ b/test/test_toc_tag.rb
@@ -8,12 +8,12 @@ class TestTableOfContentsTag < Minitest::Test
   def setup
     @stubbed_context  = Struct.new(:registers)
     @stubbed_context1 = Struct.new(:config)
-    @stubbed_context2 = Struct.new(:toc, :content)
+    @stubbed_context2 = Struct.new(:toc, :content, :toc_config)
   end
 
   def test_toc_tag
     context = @stubbed_context.new({
-                                     page: @stubbed_context2.new({ 'toc' => false }, '<h1>test</h1>'),
+                                     page: @stubbed_context2.new(true, '<h1>test</h1>', nil),
                                      site: @stubbed_context1.new({ 'toc' => nil })
                                    })
     tag = Jekyll::TocTag.parse('toc_tag', '', Tokenizer.new(''), ParseContext.new)
@@ -22,7 +22,7 @@ class TestTableOfContentsTag < Minitest::Test
   end
 
   def test_toc_tag_returns_empty_string
-    context = @stubbed_context.new({ page: { 'toc' => false } })
+    context = @stubbed_context.new({ page: { 'toc' => false, 'toc_config' => nil } })
     tag = Jekyll::TocTag.parse('toc_tag', '', Tokenizer.new(''), ParseContext.new)
 
     assert_empty tag.render(context)


### PR DESCRIPTION
Something I needed. Works on my website so you can have different levels depending on your content.

Could you consider this one?