### PR TITLE
ci: Add Ruby 3.4 and 4.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "4.0"]
         gemfile:
           - gemfiles/jekyll_3.9.gemfile
           - gemfiles/jekyll_4.0.gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'appraisal'
+gem 'base64'
+gem 'bigdecimal'
+gem 'csv'
 gem 'minitest-reporters'
 gem 'minitest'
 gem 'pry'

--- a/gemfiles/jekyll_3.9.gemfile
+++ b/gemfiles/jekyll_3.9.gemfile
@@ -3,6 +3,9 @@
 source "https://rubygems.org"
 
 gem "appraisal"
+gem "base64"
+gem "bigdecimal"
+gem "csv"
 gem "minitest-reporters"
 gem "minitest"
 gem "pry"

--- a/gemfiles/jekyll_4.0.gemfile
+++ b/gemfiles/jekyll_4.0.gemfile
@@ -3,6 +3,9 @@
 source "https://rubygems.org"
 
 gem "appraisal"
+gem "base64"
+gem "bigdecimal"
+gem "csv"
 gem "minitest-reporters"
 gem "minitest"
 gem "pry"

--- a/gemfiles/jekyll_4.1.gemfile
+++ b/gemfiles/jekyll_4.1.gemfile
@@ -3,6 +3,9 @@
 source "https://rubygems.org"
 
 gem "appraisal"
+gem "base64"
+gem "bigdecimal"
+gem "csv"
 gem "minitest-reporters"
 gem "minitest"
 gem "pry"

--- a/gemfiles/jekyll_4.2.gemfile
+++ b/gemfiles/jekyll_4.2.gemfile
@@ -3,6 +3,9 @@
 source "https://rubygems.org"
 
 gem "appraisal"
+gem "base64"
+gem "bigdecimal"
+gem "csv"
 gem "minitest-reporters"
 gem "minitest"
 gem "pry"

--- a/gemfiles/jekyll_4.3.gemfile
+++ b/gemfiles/jekyll_4.3.gemfile
@@ -3,6 +3,9 @@
 source "https://rubygems.org"
 
 gem "appraisal"
+gem "base64"
+gem "bigdecimal"
+gem "csv"
 gem "minitest-reporters"
 gem "minitest"
 gem "pry"


### PR DESCRIPTION
This pull request updates the Ruby and gem dependencies to improve compatibility and ensure all required libraries are available in all environments. The most important changes include expanding the Ruby version matrix for CI and explicitly adding several standard libraries to the gem dependencies.

**CI/CD Improvements:**

* Updated the CI workflow in `.github/workflows/ci.yml` to test against Ruby versions 3.4 and 4.0, in addition to the previously supported versions, ensuring broader compatibility.

**Dependency Management:**

* Added `base64`, `bigdecimal`, and `csv` gems to the main `Gemfile` and all Jekyll-specific gemfiles (`gemfiles/jekyll_3.9.gemfile`, `gemfiles/jekyll_4.0.gemfile`, `gemfiles/jekyll_4.1.gemfile`, `gemfiles/jekyll_4.2.gemfile`, `gemfiles/jekyll_4.3.gemfile`) to ensure these standard libraries are explicitly available regardless of Ruby version or environment. [[1]](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fR6-R8) [[2]](diffhunk://#diff-191256552e68ae9d3cd547f6b590b91401ce897c4837e53a7c7145af5991d4b6R6-R8) [[3]](diffhunk://#diff-a2b45aab517e4d0853de745b164e4b6d50761ebaac5f58287dd300c70c27e84dR6-R8) [[4]](diffhunk://#diff-b78a0c5af84b9ff1975bcdce8723e599dcd5b741fca96464d8e02e7648c44d21R6-R8) [[5]](diffhunk://#diff-6d3e40fab9987df1de1891d057e8e6f92fbf72cdb0776793b6d7f67f8b8ac073R6-R8) [[6]](diffhunk://#diff-79855ba722bc9ffef9c3f72fb19bde86362987d31be4333ed33f73957eff0fb5R6-R8)